### PR TITLE
Improved auto-completion. Fix paste at cursor bug.

### DIFF
--- a/PythonConsoleControl/PythonConsole.cs
+++ b/PythonConsoleControl/PythonConsole.cs
@@ -309,11 +309,11 @@ namespace PythonConsoleControl
                     else if (rectangular && textArea.Selection.IsEmpty)
                     {
                         if (!RectangleSelection.PerformRectangularPaste(textArea, textArea.Caret.Position, text, false))
-                            textEditor.Write(text, false);
+                            textEditor.Write(text, false, false);
                     }
                     else
                     {
-                        textEditor.Write(text, false);
+                        textEditor.Write(text, false, false);
                     }
                 }
                 textArea.Caret.BringCaretToView();

--- a/PythonConsoleControl/PythonConsole.cs
+++ b/PythonConsoleControl/PythonConsole.cs
@@ -54,7 +54,7 @@ namespace PythonConsoleControl
             }
         }
 
-        bool allowCtrlSpaceAutocompletion = false;
+        bool allowCtrlSpaceAutocompletion = true;
         public bool AllowCtrlSpaceAutocompletion
         {
             get { return allowCtrlSpaceAutocompletion; }

--- a/PythonConsoleControl/PythonConsole.cs
+++ b/PythonConsoleControl/PythonConsole.cs
@@ -571,7 +571,7 @@ namespace PythonConsoleControl
         {
             if (e.Text.Length > 0)
             {
-                if (!char.IsLetterOrDigit(e.Text[0]))
+                if (!char.IsLetterOrDigit(e.Text[0]) || e.Text[0] == '_') // Underscore is a fairly common character in Revit API names.
                 {
                     // Whenever a non-letter is typed while the completion window is open,
                     // insert the currently selected element.


### PR DESCRIPTION
Hi Daren

I've incorporated a couple of improvements to the auto-completion functionality.  This expands ctrl+space auto-complete to auto-complete on partial names (not just immediately after a dot), which includes global names (i.e. in the absence of a preceding dot, global names are matched). Auto-complete will now work inside expressions involving parentheses or brackets, e.g. completing an argument to a function, inside an expression, etc.). Underscores are allowed as a part of the auto-complete name (quite common in Revit API enums) which prevents the auto-complete window from closing when typing them.

Also added a fix to pasting text in the interpreter window so that now, if nothing is selected, the text is inserted at the cursor position as opposed to being pasted at the end of the line.

Let me know of any questions or code formatting improvements / comments needed.

[I have more improvements on the way if you'd like! (e.g. Save as, show name of current script filename in title bar, asterisk for modified / unsaved script file, etc.). Also a dark themed UI!]