### PR TITLE
Fixes issue with Settings path added to search paths multiple times

### DIFF
--- a/RevitPythonShell/RevitPythonShellApplication.cs
+++ b/RevitPythonShell/RevitPythonShellApplication.cs
@@ -503,6 +503,7 @@ namespace RevitPythonShell
             string startupScript)
         {
             var doc = GetSettings();
+            var settingsFolder = GetSettingsFolder();
 
             // clean out current stuff
             foreach (var xmlExistingCommands in (doc.Root.Descendants("Commands") ?? new List<XElement>()).ToList())
@@ -546,6 +547,13 @@ namespace RevitPythonShell
                 xmlSearchPaths.Add(new XElement(
                     "SearchPath",
                         new XAttribute("name", path)));
+
+            }
+            // ensure settings directory is added to the search paths
+            if (!searchPaths.Contains(settingsFolder)) {
+                xmlSearchPaths.Add(new XElement(
+                    "SearchPath",
+                        new XAttribute("name", settingsFolder)));
 
             }
             doc.Root.Add(xmlSearchPaths);

--- a/RpsRuntime/RpsConfig.cs
+++ b/RpsRuntime/RpsConfig.cs
@@ -35,7 +35,6 @@ namespace RevitPythonShell.RpsRuntime
             {
                 yield return searchPathNode.Attribute("name").Value;
             }
-            yield return System.IO.Path.GetDirectoryName(_settingsPath);
         }
 
         /// <summary>


### PR DESCRIPTION
Resolved an issue with search path duplication. The RPS settings path would be added to the search paths on every configuration save.

IMPORTANT: See PR#74 before merging