### PR TITLE
Added Revit 2021 build targets & assembly references for dotnet48

### DIFF
--- a/PythonConsoleControl/PythonConsoleControl.csproj
+++ b/PythonConsoleControl/PythonConsoleControl.csproj
@@ -15,9 +15,10 @@
               2018  |  net46
               2019  |  net47
               2020  |  net471
+              2021  |  net48
       For example you can exclude Revit 2014, by simply removing net40 target belows
       -->
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net472</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>
@@ -29,7 +30,7 @@
          e.g. if you want to debug ONLY Revit 2019,
          put net47 below and switch to 'Debug One' configuration
       -->
-    <TargetFrameworks>net40</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
@@ -52,6 +53,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <RevitVersion>2020</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <RevitVersion>2021</RevitVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -99,6 +103,7 @@
     <PackageReference Include="Autodesk.Revit.SDK" Version="2018.*" Condition=" '$(RevitVersion)' == '2018' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2019.*" Condition=" '$(RevitVersion)' == '2019' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2020.1.0" Condition=" '$(RevitVersion)' == '2020' " PrivateAssets="All" />
+    <PackageReference Include="Autodesk.Revit.SDK" Version="2021.*" Condition=" '$(RevitVersion)' == '2021' " PrivateAssets="All" />
     <PackageReference Include="AvalonEdit" Version="6.0.1"/>
  
   </ItemGroup>

--- a/PythonConsoleControl/PythonConsoleControl.csproj
+++ b/PythonConsoleControl/PythonConsoleControl.csproj
@@ -18,7 +18,7 @@
               2021  |  net48
       For example you can exclude Revit 2014, by simply removing net40 target belows
       -->
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net472</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net48</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
   </PropertyGroup>

--- a/RevitPythonShell/Properties/launchSettings.json
+++ b/RevitPythonShell/Properties/launchSettings.json
@@ -3,50 +3,46 @@
     "Revit 2020": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2020\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2020 W Drive": {
       "commandName": "Executable",
       "executablePath": "W:\\Program Files\\Autodesk\\Revit 2020\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2019": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2019\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2018": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2018\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2017": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2017\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2016": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2016\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2015": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2015\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
     },
     "Revit 2014": {
       "commandName": "Executable",
       "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2014\\Revit.exe",
-      "commandLineArgs": "",
       "use64Bit": true
+    },
+    "Revit 2021": {
+      "commandName": "Executable",
+      "executablePath": "%ProgramW6432%\\Autodesk\\Revit 2021\\Revit.exe"
     }
   }
 }

--- a/RevitPythonShell/RevitPythonShell.csproj
+++ b/RevitPythonShell/RevitPythonShell.csproj
@@ -15,9 +15,10 @@
               2018  |  net46
               2019  |  net47
               2020  |  net471
+              2021  |  net48
       For example you can exclude Revit 2014, by simply removing net40 target belows
       -->
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net48</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
@@ -30,7 +31,7 @@
          e.g. if you want to debug ONLY Revit 2019,
          put net47 below and switch to 'Debug One' configuration
       -->
-    <TargetFrameworks>net471</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
@@ -51,10 +52,12 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <RevitVersion>2019</RevitVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <RevitVersion>2020</RevitVersion>
   </PropertyGroup>
-
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <RevitVersion>2021</RevitVersion>
+  </PropertyGroup>
   <PropertyGroup>
     <!-- Forcibly set platform to 'x64' and ignore architecture-related problems -->
     <PlatformTarget>x64</PlatformTarget>
@@ -91,7 +94,7 @@
     <OutputPath>.\bin\$(Configuration)\$(RevitVersion)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug One|net471|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug One|net472|x64'">
     <Optimize>false</Optimize>
   </PropertyGroup>
 
@@ -108,6 +111,7 @@
     <PackageReference Include="Autodesk.Revit.SDK" Version="2018.*" Condition=" '$(RevitVersion)' == '2018' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2019.*" Condition=" '$(RevitVersion)' == '2019' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2020.*" Condition=" '$(RevitVersion)' == '2020' " PrivateAssets="All" />
+    <PackageReference Include="Autodesk.Revit.SDK" Version="2021.*" Condition=" '$(RevitVersion)' == '2021' " PrivateAssets="All" />
     <PackageReference Include="AvalonEdit" Version="6.0.1"/>
   </ItemGroup>
 

--- a/RevitPythonShell/RevitPythonShell.csproj
+++ b/RevitPythonShell/RevitPythonShell.csproj
@@ -94,7 +94,7 @@
     <OutputPath>.\bin\$(Configuration)\$(RevitVersion)</OutputPath>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug One|net472|x64'">
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug One|net48|x64'">
     <Optimize>false</Optimize>
   </PropertyGroup>
 

--- a/RevitPythonShell/RevitPythonShell.csproj
+++ b/RevitPythonShell/RevitPythonShell.csproj
@@ -18,7 +18,7 @@
               2021  |  net48
       For example you can exclude Revit 2014, by simply removing net40 target belows
       -->
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net48</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net48</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
@@ -52,7 +52,7 @@
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net47' ">
     <RevitVersion>2019</RevitVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <RevitVersion>2020</RevitVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">

--- a/RevitPythonShell/RevitPythonShell.csproj.user
+++ b/RevitPythonShell/RevitPythonShell.csproj.user
@@ -4,8 +4,11 @@
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <PropertyGroup>
-    <ActiveDebugProfile>Revit 2020 W Drive</ActiveDebugProfile>
+    <ActiveDebugProfile>Revit 2021</ActiveDebugProfile>
     <ShowAllFiles>false</ShowAllFiles>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug One|net472|x64'">
+    <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>
   </PropertyGroup>
   <ItemGroup>
     <None Update="Manifests\AddinTemplate.addin">

--- a/RpsRuntime/RpsRuntime.csproj
+++ b/RpsRuntime/RpsRuntime.csproj
@@ -15,9 +15,10 @@
               2018  |  net46
               2019  |  net47
               2020  |  net471
+              2021  |  net472
       For example you can exclude Revit 2014, by simply removing net40 target belows
       -->
-    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net451;net452;net46;net47;net471;net48</TargetFrameworks>
     <RuntimeIdentifiers>win</RuntimeIdentifiers>
   </PropertyGroup>
 
@@ -28,7 +29,7 @@
          e.g. if you want to debug ONLY Revit 2019,
          put net47 below and switch to 'Debug One' configuration
       -->
-    <TargetFrameworks>net471</TargetFrameworks>
+    <TargetFrameworks>net48</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net40' ">
@@ -51,6 +52,9 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net471' ">
     <RevitVersion>2020</RevitVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net48' ">
+    <RevitVersion>2021</RevitVersion>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -103,6 +107,7 @@
     <PackageReference Include="Autodesk.Revit.SDK" Version="2018.*" Condition=" '$(RevitVersion)' == '2018' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2019.*" Condition=" '$(RevitVersion)' == '2019' " PrivateAssets="All" />
     <PackageReference Include="Autodesk.Revit.SDK" Version="2020.1.0" Condition=" '$(RevitVersion)' == '2020' " PrivateAssets="All" />
+    <PackageReference Include="Autodesk.Revit.SDK" Version="2021.*" Condition=" '$(RevitVersion)' == '2021' " PrivateAssets="All" />
     <PackageReference Include="AvalonEdit" Version="6.0.1"/>
   </ItemGroup>
 


### PR DESCRIPTION
All i did was add some additional stuff to the projects in the solution. I hope this allows people to build their own 2021 revit python shell.
I know you won't be maintaining this anymore, but I was hoping we could still get a working 2021 build. As a sendoff.

Wish I could do more, but my current knowledge on the matter is a bit too sparse I fear.