### PR TITLE
Update Support use method from revitlookup to snoop

### DIFF
--- a/RevitPythonShell/DefaultConfig/init.py
+++ b/RevitPythonShell/DefaultConfig/init.py
@@ -51,7 +51,7 @@ class RevitLookup(object):
         try:
             rlapp = [app for app in uiApplication.LoadedApplications
                      if app.GetType().Namespace == 'RevitLookup'
-                     and app.GetType().Name == 'App'][0]
+                     and app.GetType().Name == 'Application'][0]
         except IndexError:
             self.RevitLookup = None
             return
@@ -60,32 +60,61 @@ class RevitLookup(object):
         import RevitLookup
         self.RevitLookup = RevitLookup
         # See note in CollectorExt.cs in the RevitLookup source:
-        self.RevitLookup.Snoop.CollectorExts.CollectorExt.m_app = uiApplication
-        self.revit = uiApplication
-
-    def lookup(self, element):
+        #self.RevitLookup.Snoop.CollectorExts.CollectorExt.m_app = uiApplication
+        #self.revit = uiApplication
+    def IsInstalled(self):
         if not self.RevitLookup:
             print('RevitLookup not installed. Visit https://github.com/jeremytammik/RevitLookup to install.')
-            return
-        if isinstance(element, int):
-            element = self.revit.ActiveUIDocument.Document.GetElement(ElementId(element))
-        if isinstance(element, ElementId):
-            element = self.revit.ActiveUIDocument.Document.GetElement(element)
-        if isinstance(element, list):
-            elementSet = ElementSet()
-            for e in element:
-                elementSet.Insert(e)
-            element = elementSet
-        form = self.RevitLookup.Snoop.Forms.Objects(element)
-        form.ShowDialog()
+            return False
+        return True
+
+    def SnoopCurrentSelection(self):
+        if self.IsInstalled()== True:
+            form = self.RevitLookup.Views.ObjectsView()
+            form.SnoopAndShow(self.RevitLookup.Core.Selector.SnoopCurrentSelection)
+    def SnoopElement(self,element):
+        if self.IsInstalled()== True:
+            if element is None:
+                print("element null object, Please input element to snoop")
+                return
+            if isinstance(element, int):
+                element = doc.GetElement(ElementId(element))
+            if isinstance(element, ElementId):
+                element = doc.GetElement(element)
+            if isinstance(element, list):
+                elementSet = ElementSet()
+                for e in element:
+                    elementSet.Insert(e)
+                element = elementSet
+            form = self.RevitLookup.Views.ObjectsView(element)
+            self.RevitLookup.Core.ModelessWindowFactory.Show(form)
+    def SnoopActiveView():
+        if self.IsInstalled()== True:
+            self.SnoopElement(doc.ActiveView)
+    def SnoopDB(self):
+        if self.IsInstalled()== True:
+            form = self.RevitLookup.Views.ObjectsView()
+            form.SnoopAndShow(self.RevitLookup.Core.Selector.SnoopDb)
 
 
 _revitlookup = RevitLookup(__revit__)
 
 
-def lookup(element):
-    _revitlookup.lookup(element)
 
+def SnoopCurrentSelection():
+    _revitlookup.LookupCurrentSelection()
+'''
+## Example :
+## _revitlookup.SnoopElement(doc.ActiveView)
+## _revitlookup.SnoopElement(959510)
+## _revitlookup.SnoopElement(doc.ActiveView.Id)
+'''
+def SnoopElement(element):
+    _revitlookup.SnoopElement(element)
+def SnoopActiveView():
+    _revitlookup.SnoopActiveView()
+def SnoopDB():
+    _revitlookup.SnoopDB()
 # ------------------------------------------------------------------------------
 
 

--- a/RevitPythonShell/DefaultConfig/init.py
+++ b/RevitPythonShell/DefaultConfig/init.py
@@ -102,7 +102,7 @@ _revitlookup = RevitLookup(__revit__)
 
 
 def SnoopCurrentSelection():
-    _revitlookup.LookupCurrentSelection()
+    _revitlookup.SnoopCurrentSelection()
 '''
 ## Example :
 ## _revitlookup.SnoopElement(doc.ActiveView)


### PR DESCRIPTION
### Purpose

Support use some method from console connect with [RevitLookup](https://github.com/jeremytammik/RevitLookup) to snoop: 
- SnoopCurrentSelection
- SnoopElement
  - Element
  - ElementId
  - Id of Element
  - List Element
- SnoopActiveView
- SnoopDB

### Description

It fix for update from [RevitLookup](https://github.com/jeremytammik/RevitLookup) open source latest 
Demo : 
![Revit_ggJunCyj8v](https://user-images.githubusercontent.com/31106432/176649030-d07dc40e-8662-47af-8a0b-528128c45384.gif)

### Declarations

Check these if you believe they are true

- [x] This PR fix bug
- [x] This PR for new feature
- [x] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@daren-thomas @eirannejad 

### FYIs

@jeremytammik 
