### PR TITLE
Fix set CollectorExt.m_app error

### DIFF
--- a/RevitPythonShell/DefaultConfig/init.py
+++ b/RevitPythonShell/DefaultConfig/init.py
@@ -60,7 +60,10 @@ class RevitLookup(object):
         import RevitLookup
         self.RevitLookup = RevitLookup
         # See note in CollectorExt.cs in the RevitLookup source:
-        self.RevitLookup.Snoop.CollectorExts.CollectorExt.m_app = uiApplication
+        try:
+            self.RevitLookup.Snoop.CollectorExts.CollectorExt.m_app = uiApplication
+        except TypeError: # assigning m_app is now not required and even not possible
+            pass
         self.revit = uiApplication
 
     def lookup(self, element):


### PR DESCRIPTION
### Purpose

Assigning m_app is apparently not required anymore in last RevitLookup versions and not even possible.

### Description

Avoid error when loading RevitLookup.
Error:
```python
Traceback (most recent call last):
  File "<string>", line 83, in <module>
  File "<string>", line 63, in __init__
TypeError: can't set attributes of built-in/extension type 'CollectorExt'
```

### Declarations

Check these if you believe they are true

- [X] This PR fix bug
- [ ] This PR for new feature
- [ ] The codebase is in a better state after this PR
- [ ] The level of testing this PR includes is appropriate
- [ ] User facing strings, if any, are extracted into `*.resx` files
- [ ] Snapshot of UI changes, if any.
- [ ] This PR modifies some build requirements and the readme is updated

### Reviewers

@daren-thomas or @eirannejad  ?
