### PR TITLE
Using Roslyn to build dlls; Dark theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ docs/_build/
 
 # Visual Studio 2015 cache/options directory
 .vs/
+
+# claude
+.claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+- 2026-01-15 **2.3.0**
+  - Use Roslyn to build dlls for "Deploy RpsAddin", fixes issue [#167](https://github.com/architecture-building-systems/revitpythonshell/issues/167)
+  - Introduce Dark theme for Revit 2024+
 - 2025-04-03 **2.2.0**
   - Support Autodesk Revit version 2026.
 - 2025-04-03 **2.1.0**

--- a/Installer/Installer.cs
+++ b/Installer/Installer.cs
@@ -12,7 +12,7 @@ const string installationDir = @"%AppDataFolder%\Autodesk\Revit\Addins\";
 const string projectName = "RevitPythonShell";
 const string outputName = "RevitPythonShell";
 const string outputDir = "output";
-const string version = "2.2.0";
+const string version = "2.3.0";
 
 var fileName = new StringBuilder().Append(outputName).Append("-").Append(version);
 var project = new Project

--- a/PythonConsoleControl/PythonConsoleControl.csproj
+++ b/PythonConsoleControl/PythonConsoleControl.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configurations>Debug;Release</Configurations>
     <PublishSingleFile>true</PublishSingleFile>
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\Python.xshd" />
+    <EmbeddedResource Include="Resources\Python-Dark.xshd" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/PythonConsoleControl/PythonConsoleControl.csproj
+++ b/PythonConsoleControl/PythonConsoleControl.csproj
@@ -1,12 +1,12 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Configurations>Debug;Release</Configurations>
     <PublishSingleFile>true</PublishSingleFile>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFrameworks>net48;net8.0-windows</TargetFrameworks>
     <PlatformTarget>x64</PlatformTarget>
     <LangVersion>latest</LangVersion>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <EnableDefaultItems>false</EnableDefaultItems>
+    <UseWPF>true</UseWPF>
   </PropertyGroup>
   <PropertyGroup Condition="$(Configuration.Contains('Debug'))">
     <DefineConstants>$(DefineConstants);DEBUG</DefineConstants>
@@ -16,7 +16,7 @@
     <PackageReference Include="AvalonEdit" Version="6.3.0.90" />
     <PackageReference Include="IronPython" Version="3.4.1" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <Reference Include="IronPython">
       <HintPath>..\RequiredLibraries\IronPython.dll</HintPath>
     </Reference>
@@ -32,8 +32,6 @@
     <Reference Include="Microsoft.Scripting.Metadata">
       <HintPath>..\RequiredLibraries\Microsoft.Scripting.Metadata.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
@@ -51,9 +49,7 @@
     <Compile Include="PythonConsoleCompletionDataProvider.cs" />
     <Compile Include="PythonConsole.cs" />
     <Compile Include="PythonConsoleCompletionWindow.cs" />
-    <Compile Include="PythonConsoleControl.xaml.cs">
-      <DependentUpon>PythonConsoleControl.xaml</DependentUpon>
-    </Compile>
+    <Compile Include="PythonConsoleControl.xaml.cs" />
     <Compile Include="PythonConsoleHighlightingColorizer.cs" />
     <Compile Include="PythonConsoleHost.cs" />
     <Compile Include="PythonConsolePad.cs" />

--- a/PythonConsoleControl/PythonConsoleControl.xaml
+++ b/PythonConsoleControl/PythonConsoleControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="PythonConsoleControl.IronPythonConsoleControl"
+<UserControl x:Class="PythonConsoleControl.IronPythonConsoleControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
@@ -8,6 +8,6 @@
     <!-- 
 	Copyright (c) 2010 Joe Moorhouse
     -->
-    <Grid x:Name="Grid">            
+    <Grid x:Name="Grid" Background="{DynamicResource ThemeConsoleBackground}">
     </Grid>
 </UserControl>

--- a/PythonConsoleControl/PythonConsoleControl.xaml.cs
+++ b/PythonConsoleControl/PythonConsoleControl.xaml.cs
@@ -16,8 +16,8 @@ namespace PythonConsoleControl
     /// </summary>
     public partial class IronPythonConsoleControl : UserControl
     {
-        private const string LightHighlightingName = "Python Console Highlighting v4";
-        private const string DarkHighlightingName = "Python Console Dark Highlighting v4";
+        private const string LightHighlightingName = "Python Console Highlighting";
+        private const string DarkHighlightingName = "Python Console Dark Highlighting";
         private const string LightHighlightingResource = "PythonConsoleControl.Resources.Python.xshd";
         private const string DarkHighlightingResource = "PythonConsoleControl.Resources.Python-Dark.xshd";
 

--- a/PythonConsoleControl/PythonConsoleControl.xaml.cs
+++ b/PythonConsoleControl/PythonConsoleControl.xaml.cs
@@ -9,7 +9,6 @@ using ICSharpCode.AvalonEdit;
 using ICSharpCode.AvalonEdit.Highlighting;
 using ICSharpCode.AvalonEdit.Rendering;
 
-
 namespace PythonConsoleControl
 {
     /// <summary>
@@ -17,12 +16,13 @@ namespace PythonConsoleControl
     /// </summary>
     public partial class IronPythonConsoleControl : UserControl
     {
-        private const string LightHighlightingName = "Python Console Highlighting";
-        private const string DarkHighlightingName = "Python Console Dark Highlighting";
+        private const string LightHighlightingName = "Python Console Highlighting v4";
+        private const string DarkHighlightingName = "Python Console Dark Highlighting v4";
         private const string LightHighlightingResource = "PythonConsoleControl.Resources.Python.xshd";
         private const string DarkHighlightingResource = "PythonConsoleControl.Resources.Python-Dark.xshd";
 
         private readonly PythonConsolePad _pad;
+        private Brush _currentForeground;
 
         /// <summary>
         /// Perform the action on an already instantiated PythonConsoleHost.
@@ -42,27 +42,56 @@ namespace PythonConsoleControl
 
         public void ApplyTheme(bool useDarkTheme)
         {
-            ApplyThemeResources();
+            _currentForeground = GetForegroundBrush(useDarkTheme);
+            ApplyThemeResources(useDarkTheme);
             var highlightingDefinition = GetHighlightingDefinition(
                 useDarkTheme ? DarkHighlightingResource : LightHighlightingResource,
                 useDarkTheme ? DarkHighlightingName : LightHighlightingName);
             ApplyHighlighting(highlightingDefinition);
+            
+            // Force redraw of the text view
+            _pad.Control.TextArea.TextView.Redraw();
         }
 
-        private void ApplyThemeResources()
+        private Brush GetForegroundBrush(bool useDarkTheme)
+        {
+            Brush foregroundBrush = TryFindResource("ThemeConsoleForeground") as Brush;
+            if (foregroundBrush == null)
+            {
+                foregroundBrush = useDarkTheme
+                    ? new SolidColorBrush(Color.FromRgb(0xD4, 0xD4, 0xD4))  // #D4D4D4
+                    : new SolidColorBrush(Colors.Black);
+            }
+            return foregroundBrush;
+        }
+
+        private void ApplyThemeResources(bool useDarkTheme)
         {
             TextEditor editor = _pad.Control;
-            Brush backgroundBrush = TryFindResource("ThemeConsoleBackground") as Brush;
-            Brush foregroundBrush = TryFindResource("ThemeConsoleForeground") as Brush;
 
-            if (backgroundBrush != null)
+            // Try to find resources from the visual tree (parent window)
+            Brush backgroundBrush = TryFindResource("ThemeConsoleBackground") as Brush;
+
+            // If not found in resources, use hardcoded values based on theme
+            // Revit dark theme uses blue-gray colors
+            if (backgroundBrush == null)
             {
-                editor.Background = backgroundBrush;
+                backgroundBrush = useDarkTheme
+                    ? new SolidColorBrush(Color.FromRgb(0x1F, 0x2D, 0x3D))  // #1F2D3D - Revit dark blue-gray
+                    : new SolidColorBrush(Colors.White);
             }
 
-            if (foregroundBrush != null)
+            // Apply background and foreground
+            _pad.SetBackground(backgroundBrush);
+            _pad.SetForeground(_currentForeground);
+
+            // Also set the line number margin colors if showing line numbers
+            if (editor.ShowLineNumbers)
             {
-                editor.Foreground = foregroundBrush;
+                var lineNumbersForeground = useDarkTheme
+                    ? new SolidColorBrush(Color.FromRgb(0x85, 0x85, 0x85))  // #858585
+                    : new SolidColorBrush(Color.FromRgb(0x99, 0x99, 0x99));
+                editor.LineNumbersForeground = lineNumbersForeground;
             }
         }
 
@@ -97,16 +126,25 @@ namespace PythonConsoleControl
             editor.SyntaxHighlighting = highlightingDefinition;
 
             IList<IVisualLineTransformer> lineTransformers = editor.TextArea.TextView.LineTransformers;
-            for (int transformerIndex = 0; transformerIndex < lineTransformers.Count; ++transformerIndex)
+
+            // First, remove any existing HighlightingColorizer (including our custom one)
+            for (int i = lineTransformers.Count - 1; i >= 0; i--)
             {
-                if (lineTransformers[transformerIndex] is HighlightingColorizer)
+                if (lineTransformers[i] is HighlightingColorizer)
                 {
-                    lineTransformers[transformerIndex] = new PythonConsoleHighlightingColorizer(highlightingDefinition, editor.Document);
-                    return;
+                    lineTransformers.RemoveAt(i);
                 }
             }
 
-            lineTransformers.Add(new PythonConsoleHighlightingColorizer(highlightingDefinition, editor.Document));
+            // Add our custom colorizer with the output foreground
+            var newColorizer = new PythonConsoleHighlightingColorizer(highlightingDefinition, editor.Document)
+            {
+                OutputForeground = _currentForeground
+            };
+            lineTransformers.Add(newColorizer);
+
+            // Force redraw to apply new colors
+            editor.TextArea.TextView.Redraw();
         }
 
         public PythonConsolePad Pad

--- a/PythonConsoleControl/PythonConsoleHighlightingColorizer.cs
+++ b/PythonConsoleControl/PythonConsoleHighlightingColorizer.cs
@@ -1,46 +1,75 @@
-﻿// Copyright (c) 2010 Joe Moorhouse
+// Copyright (c) 2010 Joe Moorhouse
 
 using System;
+using System.Windows.Media;
 using ICSharpCode.AvalonEdit.Document;
 using ICSharpCode.AvalonEdit.Highlighting;
+using ICSharpCode.AvalonEdit.Rendering;
 
 namespace PythonConsoleControl
 {
     /// <summary>
-    /// Only colourize when text is input
+    /// Custom colorizer for the Python console that handles both input lines (with syntax highlighting)
+    /// and output lines (with a configurable foreground color).
     /// </summary>
     public class PythonConsoleHighlightingColorizer : HighlightingColorizer
     {
-        TextDocument document;
+        private readonly TextDocument _document;
+        private Brush _outputForeground;
 
         /// <summary>
-        /// Creates a new HighlightingColorizer instance.
+        /// Gets or sets the foreground brush for output lines (lines not starting with >>> or ...).
         /// </summary>
-        /// <param name="ruleSet">The root highlighting rule set.</param>
-        public PythonConsoleHighlightingColorizer(IHighlightingDefinition ruleSet, TextDocument document)
-            : base(ruleSet)
+        public Brush OutputForeground
         {
-            if (document == null)
-                throw new ArgumentNullException("document");
-            this.document = document;
+            get => _outputForeground;
+            set => _outputForeground = value;
+        }
+
+        /// <summary>
+        /// Creates a new PythonConsoleHighlightingColorizer instance.
+        /// </summary>
+        /// <param name="highlightingDefinition">The highlighting definition to use for input lines.</param>
+        /// <param name="document">The text document.</param>
+        public PythonConsoleHighlightingColorizer(IHighlightingDefinition highlightingDefinition, TextDocument document)
+            : base(highlightingDefinition)
+        {
+            _document = document ?? throw new ArgumentNullException(nameof(document));
         }
 
         /// <inheritdoc/>
         protected override void ColorizeLine(DocumentLine line)
         {
-            IHighlighter highlighter = CurrentContext.TextView.Services.GetService(typeof(IHighlighter)) as IHighlighter;
-            string lineString = document.GetText(line);
-            if (highlighter != null)
+            if (line.Length == 0)
+                return;
+
+            string lineString = _document.GetText(line);
+
+            // Check if this is an input line (starts with >>> or ...)
+            bool isInputLine = lineString.Length >= 3 &&
+                (lineString.StartsWith(">>>") || lineString.StartsWith("..."));
+
+            if (isInputLine)
             {
-                if (lineString.Length < 3 || lineString.Substring(0, 3) == ">>>" || lineString.Substring(0, 3) == "...") {
+                // Apply syntax highlighting to input lines
+                IHighlighter highlighter = CurrentContext.TextView.Services.GetService(typeof(IHighlighter)) as IHighlighter;
+                if (highlighter != null)
+                {
                     HighlightedLine hl = highlighter.HighlightLine(line.LineNumber);
                     foreach (HighlightedSection section in hl.Sections)
                     {
                         ChangeLinePart(section.Offset, section.Offset + section.Length,
-                                       visualLineElement => ApplyColorToElement(visualLineElement, section.Color));
+                            visualLineElement => ApplyColorToElement(visualLineElement, section.Color));
                     }
                 }
-                else { // Could add foreground colour functionality here.
+            }
+            else
+            {
+                // Apply foreground color to output lines (errors, results, banner text, etc.)
+                if (_outputForeground != null)
+                {
+                    ChangeLinePart(line.Offset, line.EndOffset,
+                        visualLineElement => visualLineElement.TextRunProperties.SetForegroundBrush(_outputForeground));
                 }
             }
         }

--- a/PythonConsoleControl/PythonConsolePad.cs
+++ b/PythonConsoleControl/PythonConsolePad.cs
@@ -36,6 +36,25 @@ namespace PythonConsoleControl
             get { return host.Console; }
         }
 
+        /// <summary>
+        /// Sets the foreground color for the console text.
+        /// </summary>
+        public void SetForeground(Brush foreground)
+        {
+            textEditor.Foreground = foreground;
+            textEditor.TextArea.Foreground = foreground;
+            // Force the TextView to use the new foreground
+            textEditor.TextArea.TextView.LinkTextForegroundBrush = foreground;
+        }
+
+        /// <summary>
+        /// Sets the background color for the console.
+        /// </summary>
+        public void SetBackground(Brush background)
+        {
+            textEditor.Background = background;
+        }
+
         public void Dispose()
         {
             host.Dispose();

--- a/PythonConsoleControl/PythonTextEditor.cs
+++ b/PythonConsoleControl/PythonTextEditor.cs
@@ -323,7 +323,7 @@ namespace PythonConsoleControl
         /// </summary>
         internal void BackgroundShowCompletionWindow() //ICompletionItemProvider
         {
-			// provide AvalonEdit with the data:
+            // provide AvalonEdit with the data:
             string itemForCompletion = "";
             textArea.Dispatcher.Invoke(new Action(delegate()
             {
@@ -368,7 +368,7 @@ namespace PythonConsoleControl
                     MessageBox.Show(exception.ToString(), "Error");
                 }
 
-            }));            
+            }));
         }
 
         internal void BackgroundUpdateCompletionDescription()
@@ -384,7 +384,7 @@ namespace PythonConsoleControl
                     MessageBox.Show(exception.ToString(), "Error");
                 }
 
-            }));            
+            }));
         }
 
         public void RequestCompletioninsertion(TextCompositionEventArgs e)
@@ -396,6 +396,3 @@ namespace PythonConsoleControl
 
     }
 }
-
-    
-   

--- a/PythonConsoleControl/Resources/Python-Dark.xshd
+++ b/PythonConsoleControl/Resources/Python-Dark.xshd
@@ -1,0 +1,110 @@
+<SyntaxDefinition name="Python-Dark" extensions=".py">
+
+  <Properties>
+    <Property name="LineComment" value="#"/>
+  </Properties>
+
+  <Digits name="Digits" color="#B5CEA8"/>
+
+  <RuleSets>
+    <RuleSet ignorecase="false">
+
+      <Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
+
+      <Span name="DocComment" color="#6A9955">
+        <Begin>"""</Begin>
+        <End>"""</End>
+      </Span>
+
+      <Span name="SingleQuoteDocComment" color="#6A9955">
+        <Begin>'''</Begin>
+        <End>'''</End>
+      </Span>
+
+      <Span name="LineComment" stopateol="true" color="#6A9955">
+        <Begin>#</Begin>
+      </Span>
+
+      <Span name="String" stopateol="true" color="#CE9178" escapecharacter="\">
+        <Begin>"</Begin>
+        <End>"</End>
+      </Span>
+
+      <Span name="Char" stopateol="true" color="#CE9178" escapecharacter="\">
+        <Begin>'</Begin>
+        <End>'</End>
+      </Span>
+
+      <MarkPrevious bold="true" color="#DCDCAA">(</MarkPrevious>
+
+      <KeyWords name="Prompt" color="#4EC9B0" bold="true">
+        <Key word=">>>"/>
+        <Key word="..."/>
+      </KeyWords>
+
+      <KeyWords name="BuiltInStatements" bold="true" color="#C586C0">
+        <Key word="assert"/>
+        <Key word="del"/>
+        <Key word="exec"/>
+        <Key word="global"/>
+        <Key word="lambda"/>
+        <Key word="print"/>
+      </KeyWords>
+
+      <KeyWords name="ClassStatement" color="#569CD6" bold="true">
+        <Key word="class"/>
+      </KeyWords>
+
+      <KeyWords name="ExceptionHandlingStatements" bold="true" color="#C586C0">
+        <Key word="except"/>
+        <Key word="finally"/>
+        <Key word="raise"/>
+        <Key word="try"/>
+      </KeyWords>
+
+      <KeyWords name="FunctionDefinition" bold="true" color="#569CD6">
+        <Key word="def"/>
+      </KeyWords>
+
+      <KeyWords name="Imports" bold="true" color="#C586C0">
+        <Key word="import"/>
+        <Key word="from"/>
+      </KeyWords>
+
+      <KeyWords name="IterationStatements" bold="true" color="#569CD6">
+        <Key word="for"/>
+        <Key word="in"/>
+        <Key word="while"/>
+      </KeyWords>
+
+      <KeyWords name="JumpStatements" color="#C586C0">
+        <Key word="break"/>
+        <Key word="continue"/>
+        <Key word="yield"/>
+        <Key word="return"/>
+      </KeyWords>
+
+      <KeyWords name="OperatorStatements" bold="true" color="#569CD6">
+        <Key word="and"/>
+        <Key word="as"/>
+        <Key word="is"/>
+        <Key word="not"/>
+        <Key word="or"/>
+      </KeyWords>
+
+      <KeyWords name="PassStatement" color="#808080">
+        <Key word="pass"/>
+      </KeyWords>
+
+      <KeyWords name="SelectionStatements" bold="true" color="#569CD6">
+        <Key word="elif"/>
+        <Key word="else"/>
+        <Key word="if"/>
+      </KeyWords>
+
+      <KeyWords name="WithStatement" color="#4EC9B0">
+        <Key word="with"/>
+      </KeyWords>
+    </RuleSet>
+  </RuleSets>
+</SyntaxDefinition>

--- a/PythonConsoleControl/Resources/Python-Dark.xshd
+++ b/PythonConsoleControl/Resources/Python-Dark.xshd
@@ -1,110 +1,109 @@
-<SyntaxDefinition name="Python-Dark" extensions=".py">
+<?xml version="1.0"?>
+<SyntaxDefinition name="Python-Dark" extensions=".py"
+                  xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 
-  <Properties>
-    <Property name="LineComment" value="#"/>
-  </Properties>
+  <Color name="Comment" foreground="#7EC699" />
+  <Color name="String" foreground="#D7BA7D" />
+  <Color name="Char" foreground="#D7BA7D" />
+  <Color name="Digits" foreground="#B5CEA8" />
+  <Color name="Prompt" foreground="#9CDCFE" fontWeight="bold" />
+  <Color name="Keywords" foreground="#569CD6" fontWeight="bold" />
+  <Color name="ControlFlow" foreground="#C586C0" fontWeight="bold" />
+  <Color name="ClassName" foreground="#4EC9B0" fontWeight="bold" />
+  <Color name="FunctionDef" foreground="#DCDCAA" fontWeight="bold" />
+  <Color name="Exception" foreground="#F48771" fontWeight="bold" />
+  <Color name="MethodCall" foreground="#DCDCAA" fontWeight="bold" />
 
-  <Digits name="Digits" color="#B5CEA8"/>
+  <RuleSet ignoreCase="false">
 
-  <RuleSets>
-    <RuleSet ignorecase="false">
+    <Span color="Comment" multiline="true">
+      <Begin>"""</Begin>
+      <End>"""</End>
+    </Span>
 
-      <Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
+    <Span color="Comment" multiline="true">
+      <Begin>'''</Begin>
+      <End>'''</End>
+    </Span>
 
-      <Span name="DocComment" color="#6A9955">
-        <Begin>"""</Begin>
-        <End>"""</End>
-      </Span>
+    <Span color="Comment">
+      <Begin>\#</Begin>
+    </Span>
 
-      <Span name="SingleQuoteDocComment" color="#6A9955">
-        <Begin>'''</Begin>
-        <End>'''</End>
-      </Span>
+    <Span color="String">
+      <Begin>"</Begin>
+      <End>"</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="LineComment" stopateol="true" color="#6A9955">
-        <Begin>#</Begin>
-      </Span>
+    <Span color="Char">
+      <Begin>'</Begin>
+      <End>'</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="String" stopateol="true" color="#CE9178" escapecharacter="\">
-        <Begin>"</Begin>
-        <End>"</End>
-      </Span>
+    <Keywords color="Prompt">
+      <Word>&gt;&gt;&gt;</Word>
+      <Word>...</Word>
+    </Keywords>
 
-      <Span name="Char" stopateol="true" color="#CE9178" escapecharacter="\">
-        <Begin>'</Begin>
-        <End>'</End>
-      </Span>
+    <Keywords color="Keywords">
+      <Word>and</Word>
+      <Word>as</Word>
+      <Word>assert</Word>
+      <Word>del</Word>
+      <Word>exec</Word>
+      <Word>global</Word>
+      <Word>in</Word>
+      <Word>is</Word>
+      <Word>lambda</Word>
+      <Word>not</Word>
+      <Word>or</Word>
+      <Word>pass</Word>
+      <Word>print</Word>
+      <Word>with</Word>
+    </Keywords>
 
-      <MarkPrevious bold="true" color="#DCDCAA">(</MarkPrevious>
+    <Keywords color="ControlFlow">
+      <Word>break</Word>
+      <Word>continue</Word>
+      <Word>elif</Word>
+      <Word>else</Word>
+      <Word>for</Word>
+      <Word>if</Word>
+      <Word>return</Word>
+      <Word>while</Word>
+      <Word>yield</Word>
+      <Word>import</Word>
+      <Word>from</Word>
+    </Keywords>
 
-      <KeyWords name="Prompt" color="#4EC9B0" bold="true">
-        <Key word=">>>"/>
-        <Key word="..."/>
-      </KeyWords>
+    <Keywords color="ClassName">
+      <Word>class</Word>
+    </Keywords>
 
-      <KeyWords name="BuiltInStatements" bold="true" color="#C586C0">
-        <Key word="assert"/>
-        <Key word="del"/>
-        <Key word="exec"/>
-        <Key word="global"/>
-        <Key word="lambda"/>
-        <Key word="print"/>
-      </KeyWords>
+    <Keywords color="FunctionDef">
+      <Word>def</Word>
+    </Keywords>
 
-      <KeyWords name="ClassStatement" color="#569CD6" bold="true">
-        <Key word="class"/>
-      </KeyWords>
+    <Keywords color="Exception">
+      <Word>except</Word>
+      <Word>finally</Word>
+      <Word>raise</Word>
+      <Word>try</Word>
+    </Keywords>
 
-      <KeyWords name="ExceptionHandlingStatements" bold="true" color="#C586C0">
-        <Key word="except"/>
-        <Key word="finally"/>
-        <Key word="raise"/>
-        <Key word="try"/>
-      </KeyWords>
+    <Rule color="MethodCall">
+      \b[\w]+(?=\s*\()
+    </Rule>
 
-      <KeyWords name="FunctionDefinition" bold="true" color="#569CD6">
-        <Key word="def"/>
-      </KeyWords>
+    <Rule color="Digits">
+      \b0[xX][0-9a-fA-F]+|\b(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?[jJ]?\b
+    </Rule>
 
-      <KeyWords name="Imports" bold="true" color="#C586C0">
-        <Key word="import"/>
-        <Key word="from"/>
-      </KeyWords>
-
-      <KeyWords name="IterationStatements" bold="true" color="#569CD6">
-        <Key word="for"/>
-        <Key word="in"/>
-        <Key word="while"/>
-      </KeyWords>
-
-      <KeyWords name="JumpStatements" color="#C586C0">
-        <Key word="break"/>
-        <Key word="continue"/>
-        <Key word="yield"/>
-        <Key word="return"/>
-      </KeyWords>
-
-      <KeyWords name="OperatorStatements" bold="true" color="#569CD6">
-        <Key word="and"/>
-        <Key word="as"/>
-        <Key word="is"/>
-        <Key word="not"/>
-        <Key word="or"/>
-      </KeyWords>
-
-      <KeyWords name="PassStatement" color="#808080">
-        <Key word="pass"/>
-      </KeyWords>
-
-      <KeyWords name="SelectionStatements" bold="true" color="#569CD6">
-        <Key word="elif"/>
-        <Key word="else"/>
-        <Key word="if"/>
-      </KeyWords>
-
-      <KeyWords name="WithStatement" color="#4EC9B0">
-        <Key word="with"/>
-      </KeyWords>
-    </RuleSet>
-  </RuleSets>
+  </RuleSet>
 </SyntaxDefinition>

--- a/PythonConsoleControl/Resources/Python.xshd
+++ b/PythonConsoleControl/Resources/Python.xshd
@@ -1,110 +1,117 @@
-﻿<SyntaxDefinition name="Python" extensions=".py">
-	
-	<Properties>
-		<Property name="LineComment" value="#"/>
-	</Properties>
-	
-	<Digits name="Digits" color="DarkBlue"/>
+﻿<?xml version="1.0"?>
+<SyntaxDefinition name="Python" extensions=".py"
+				  xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 
-	<RuleSets>
-		<RuleSet ignorecase="false">
-			
-			<Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
-			
-			<Span name="DocComment" color="Green">
-				<Begin>"""</Begin>
-				<End>"""</End>
-			</Span>
-			
-			<Span name="SingleQuoteDocComment" color="Green">
-				<Begin>'''</Begin>
-				<End>'''</End>
-			</Span>
+  <Color name="Comment" foreground="Green" />
+  <Color name="String" foreground="Blue" />
+  <Color name="Char" foreground="Magenta" />
+  <Color name="Digits" foreground="DarkBlue" />
+  <Color name="Prompt" foreground="Blue" fontWeight="bold" />
+  <Color name="Keywords" foreground="MidnightBlue" fontWeight="bold" />
+  <Color name="ControlFlow" foreground="Blue" fontWeight="bold" />
+  <Color name="ClassName" foreground="Blue" fontWeight="bold" />
+  <Color name="FunctionDef" foreground="Blue" fontWeight="bold" />
+  <Color name="Exception" foreground="Teal" fontWeight="bold" />
+  <Color name="MethodCall" foreground="MidnightBlue" fontWeight="bold" />
+  <Color name="Operators" foreground="DarkCyan" fontWeight="bold" />
+  <Color name="Imports" foreground="Green" fontWeight="bold" />
 
-			<Span name="LineComment" stopateol="true" color="Green">
-				<Begin>#</Begin>
-			</Span>
-			
-			<Span name="String" stopateol="true" color="Blue" escapecharacter="\">
-				<Begin>"</Begin>
-				<End>"</End>
-			</Span>
-			
-			<Span name="Char" stopateol="true" color="Magenta" escapecharacter="\">
-				<Begin>'</Begin>
-				<End>'</End>
-			</Span>
-			
-			<MarkPrevious bold="true" color="MidnightBlue">(</MarkPrevious>
+  <RuleSet ignoreCase="false">
 
-      <KeyWords name="Prompt" color="Blue" bold="true">
-        <Key word=">>>"/>
-        <Key word="..."/>
-      </KeyWords>
+	<Span color="Comment" multiline="true">
+	  <Begin>"""</Begin>
+	  <End>"""</End>
+	</Span>
 
-      <KeyWords name="BuiltInStatements" bold="true" color="MidnightBlue">
-				<Key word="assert"/>
-				<Key word="del"/>
-				<Key word="exec"/>
-				<Key word="global"/>
-				<Key word="lambda"/>
-				<Key word="print"/>
-			</KeyWords>
-			
-			<KeyWords name="ClassStatement" color="Blue" bold="true">
-				<Key word="class"/>
-			</KeyWords>
-			
-			<KeyWords name="ExceptionHandlingStatements" bold="true" color="Teal">
-				<Key word="except"/>
-				<Key word="finally"/>
-				<Key word="raise"/>
-				<Key word="try"/>
-			</KeyWords>
-			
-			<KeyWords name="FunctionDefinition" bold="true" color="Blue">
-				<Key word="def"/>
-			</KeyWords>
-			
-			<KeyWords name="Imports" bold="true" color="Green">
-				<Key word="import"/>
-				<Key word="from"/>
-			</KeyWords>
-			
-			<KeyWords name="IterationStatements" bold="true" color="Blue">
-				<Key word="for"/>
-				<Key word="in"/>
-				<Key word="while"/>
-			</KeyWords>
-			
-			<KeyWords name="JumpStatements" color="Navy">
-				<Key word="break"/>
-				<Key word="continue"/>
-				<Key word="yield"/>
-				<Key word="return"/>
-			</KeyWords>
-		
-			<KeyWords name="OperatorStatements" bold="true" color="DarkCyan">
-				<Key word="and"/>
-				<Key word="as"/>
-				<Key word="is"/>
-				<Key word="not"/>
-				<Key word="or"/>
-			</KeyWords>
-			
-			<KeyWords name="PassStatement" color="Gray">
-				<Key word="pass"/>
-			</KeyWords>			
-		
-			<KeyWords name="SelectionStatements" bold="true" color="Blue">
-				<Key word="elif"/>
-				<Key word="else"/>
-				<Key word="if"/>
-			</KeyWords>
-		
-			<KeyWords name="WithStatement" color="DarkViolet">
-				<Key word="with"/>
-			</KeyWords>
-		</RuleSet>
-	</RuleSets>
+	<Span color="Comment" multiline="true">
+	  <Begin>'''</Begin>
+	  <End>'''</End>
+	</Span>
+
+	<Span color="Comment">
+	  <Begin>\#</Begin>
+	</Span>
+
+	<Span color="String">
+	  <Begin>"</Begin>
+	  <End>"</End>
+	  <RuleSet>
+		<Span begin="\\" end="." />
+	  </RuleSet>
+	</Span>
+
+	<Span color="Char">
+	  <Begin>'</Begin>
+	  <End>'</End>
+	  <RuleSet>
+		<Span begin="\\" end="." />
+	  </RuleSet>
+	</Span>
+
+	<Keywords color="Prompt">
+	  <Word>&gt;&gt;&gt;</Word>
+	  <Word>...</Word>
+	</Keywords>
+
+	<Keywords color="Keywords">
+	  <Word>assert</Word>
+	  <Word>del</Word>
+	  <Word>exec</Word>
+	  <Word>global</Word>
+	  <Word>lambda</Word>
+	  <Word>pass</Word>
+	  <Word>print</Word>
+	  <Word>with</Word>
+	</Keywords>
+
+	<Keywords color="Operators">
+	  <Word>and</Word>
+	  <Word>as</Word>
+	  <Word>in</Word>
+	  <Word>is</Word>
+	  <Word>not</Word>
+	  <Word>or</Word>
+	</Keywords>
+
+	<Keywords color="ControlFlow">
+	  <Word>break</Word>
+	  <Word>continue</Word>
+	  <Word>elif</Word>
+	  <Word>else</Word>
+	  <Word>for</Word>
+	  <Word>if</Word>
+	  <Word>return</Word>
+	  <Word>while</Word>
+	  <Word>yield</Word>
+	</Keywords>
+
+	<Keywords color="Imports">
+	  <Word>import</Word>
+	  <Word>from</Word>
+	</Keywords>
+
+	<Keywords color="ClassName">
+	  <Word>class</Word>
+	</Keywords>
+
+	<Keywords color="FunctionDef">
+	  <Word>def</Word>
+	</Keywords>
+
+	<Keywords color="Exception">
+	  <Word>except</Word>
+	  <Word>finally</Word>
+	  <Word>raise</Word>
+	  <Word>try</Word>
+	</Keywords>
+
+	<Rule color="MethodCall">
+	  \b[\w]+(?=\s*\()
+	</Rule>
+
+	<Rule color="Digits">
+	  \b0[xX][0-9a-fA-F]+|\b(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?[jJ]?\b
+	</Rule>
+
+  </RuleSet>
 </SyntaxDefinition>

--- a/README.md
+++ b/README.md
@@ -120,8 +120,8 @@ This project is licensed under the terms of the [MIT License](http://opensource.
 * [Chuong Mep](https://github.com/chuongmep/) a people like maintain for project open source.
 * [Roman Golev](https://github.com/romangolev/) (port to Revit 2025)
 * [Jean-Marc Couffin](https://github.com/jmcouffin/) (port to Revit 2026)
+* [Roman Golev](https://github.com/romangolev/) modernize dll build process by using Roslyn, Dark theme for Revit 2024+
 * many, many users with questions, bug reports etc!
-
 Also, many thanks to the
 [Chair for Architecture & Building Systems](http://systems.arch.ethz.ch) for making this project possible.
 

--- a/RevitPythonShell/Helpers/ThemeManager.cs
+++ b/RevitPythonShell/Helpers/ThemeManager.cs
@@ -141,22 +141,14 @@ namespace RevitPythonShell.Helpers
 
         public void ApplyThemeToWindow(Window window)
         {
-            ResourceDictionary themeDictionary;
-            
-            if (CurrentTheme == Theme.Dark)
+            var themeDictionary = new ResourceDictionary
             {
-                themeDictionary = new ResourceDictionary
-                {
-                    Source = new Uri("/RevitPythonShell;component/Themes/DarkTheme.xaml", UriKind.Relative)
-                };
-            }
-            else
-            {
-                themeDictionary = new ResourceDictionary
-                {
-                    Source = new Uri("/RevitPythonShell;component/Themes/LightTheme.xaml", UriKind.Relative)
-                };
-            }
+                Source = new Uri(
+                    CurrentTheme == Theme.Dark
+                        ? "/RevitPythonShell;component/Themes/DarkTheme.xaml"
+                        : "/RevitPythonShell;component/Themes/LightTheme.xaml",
+                    UriKind.Relative)
+            };
 
             window.Resources.MergedDictionaries.Clear();
             window.Resources.MergedDictionaries.Add(themeDictionary);
@@ -169,8 +161,8 @@ namespace RevitPythonShell.Helpers
                 : "RevitPythonShell.Resources.Python.xshd";
 
             string highlightingName = CurrentTheme == Theme.Dark
-                ? "Python-Dark Highlighting v4"
-                : "Python Highlighting v4";
+                ? "Python-Dark Highlighting"
+                : "Python Highlighting";
 
             IHighlightingDefinition existingHighlighting = HighlightingManager.Instance.GetDefinition(highlightingName);
             if (existingHighlighting != null)

--- a/RevitPythonShell/Helpers/ThemeManager.cs
+++ b/RevitPythonShell/Helpers/ThemeManager.cs
@@ -92,6 +92,43 @@ namespace RevitPythonShell.Helpers
             CurrentTheme = theme;
         }
 
+        public void ApplyRevitThemePreference()
+        {
+            try
+            {
+                var uiThemeManagerType = Type.GetType("Autodesk.Revit.UI.UIThemeManager, RevitAPIUI");
+                if (uiThemeManagerType == null)
+                {
+                    return;
+                }
+
+                var currentThemeProperty = uiThemeManagerType.GetProperty("CurrentTheme", BindingFlags.Public | BindingFlags.Static);
+                if (currentThemeProperty == null)
+                {
+                    return;
+                }
+
+                var currentThemeValue = currentThemeProperty.GetValue(null);
+                if (currentThemeValue == null)
+                {
+                    return;
+                }
+
+                var themeName = currentThemeValue.ToString();
+                if (string.Equals(themeName, "Dark", StringComparison.OrdinalIgnoreCase))
+                {
+                    SetTheme(Theme.Dark);
+                }
+                else if (string.Equals(themeName, "Light", StringComparison.OrdinalIgnoreCase))
+                {
+                    SetTheme(Theme.Light);
+                }
+            }
+            catch (Exception)
+            {
+            }
+        }
+
         public void ToggleTheme()
         {
             SetTheme(CurrentTheme == Theme.Light ? Theme.Dark : Theme.Light);
@@ -132,8 +169,8 @@ namespace RevitPythonShell.Helpers
                 : "RevitPythonShell.Resources.Python.xshd";
 
             string highlightingName = CurrentTheme == Theme.Dark
-                ? "Python-Dark Highlighting"
-                : "Python Highlighting";
+                ? "Python-Dark Highlighting v4"
+                : "Python Highlighting v4";
 
             IHighlightingDefinition existingHighlighting = HighlightingManager.Instance.GetDefinition(highlightingName);
             if (existingHighlighting != null)

--- a/RevitPythonShell/Helpers/ThemeManager.cs
+++ b/RevitPythonShell/Helpers/ThemeManager.cs
@@ -1,0 +1,187 @@
+using System;
+using System.IO;
+using System.Reflection;
+using System.Windows;
+using System.Xml.Linq;
+using ICSharpCode.AvalonEdit;
+using ICSharpCode.AvalonEdit.Highlighting;
+
+namespace RevitPythonShell.Helpers
+{
+    public enum Theme
+    {
+        Light,
+        Dark
+    }
+
+    public class ThemeManager
+    {
+        private const string THEME_SETTING_NAME = "Theme";
+        
+        private static ThemeManager _instance;
+        private Theme _currentTheme = Theme.Light;
+        
+        public static ThemeManager Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    _instance = new ThemeManager();
+                }
+                return _instance;
+            }
+        }
+
+        public Theme CurrentTheme
+        {
+            get { return _currentTheme; }
+            private set
+            {
+                if (_currentTheme != value)
+                {
+                    _currentTheme = value;
+                    OnThemeChanged();
+                }
+            }
+        }
+
+        public event EventHandler ThemeChanged;
+
+        private ThemeManager()
+        {
+        }
+
+        public void LoadThemeFromSettings(XDocument settings)
+        {
+            try
+            {
+                var themeElement = settings.Root.Element(THEME_SETTING_NAME);
+                if (themeElement != null)
+                {
+                    string themeValue = themeElement.Value;
+                    if (Enum.TryParse<Theme>(themeValue, out var theme))
+                    {
+                        CurrentTheme = theme;
+                        return;
+                    }
+                }
+            }
+            catch (Exception)
+            {
+            }
+            
+            CurrentTheme = Theme.Light;
+        }
+
+        public void SaveThemeToSettings(XDocument settings)
+        {
+            var existingTheme = settings.Root.Element(THEME_SETTING_NAME);
+            if (existingTheme != null)
+            {
+                existingTheme.Value = CurrentTheme.ToString();
+            }
+            else
+            {
+                settings.Root.Add(new XElement(THEME_SETTING_NAME, CurrentTheme.ToString()));
+            }
+        }
+
+        public void SetTheme(Theme theme)
+        {
+            CurrentTheme = theme;
+        }
+
+        public void ToggleTheme()
+        {
+            SetTheme(CurrentTheme == Theme.Light ? Theme.Dark : Theme.Light);
+        }
+
+        private void OnThemeChanged()
+        {
+            ThemeChanged?.Invoke(this, EventArgs.Empty);
+        }
+
+        public void ApplyThemeToWindow(Window window)
+        {
+            ResourceDictionary themeDictionary;
+            
+            if (CurrentTheme == Theme.Dark)
+            {
+                themeDictionary = new ResourceDictionary
+                {
+                    Source = new Uri("/RevitPythonShell;component/Themes/DarkTheme.xaml", UriKind.Relative)
+                };
+            }
+            else
+            {
+                themeDictionary = new ResourceDictionary
+                {
+                    Source = new Uri("/RevitPythonShell;component/Themes/LightTheme.xaml", UriKind.Relative)
+                };
+            }
+
+            window.Resources.MergedDictionaries.Clear();
+            window.Resources.MergedDictionaries.Add(themeDictionary);
+        }
+
+        public IHighlightingDefinition GetHighlightingDefinition(Assembly assembly)
+        {
+            string resourceName = CurrentTheme == Theme.Dark
+                ? "RevitPythonShell.Resources.Python-Dark.xshd"
+                : "RevitPythonShell.Resources.Python.xshd";
+
+            string highlightingName = CurrentTheme == Theme.Dark
+                ? "Python-Dark Highlighting"
+                : "Python Highlighting";
+
+            IHighlightingDefinition existingHighlighting = HighlightingManager.Instance.GetDefinition(highlightingName);
+            if (existingHighlighting != null)
+            {
+                return existingHighlighting;
+            }
+
+            using (Stream s = assembly.GetManifestResourceStream(resourceName))
+            {
+                if (s == null)
+                    throw new InvalidOperationException($"Could not find embedded resource: {resourceName}");
+                using (var reader = new System.Xml.XmlTextReader(s))
+                {
+                    var highlighting = ICSharpCode.AvalonEdit.Highlighting.Xshd.
+                        HighlightingLoader.Load(reader, HighlightingManager.Instance);
+                    
+                    HighlightingManager.Instance.RegisterHighlighting(highlightingName, new string[] { ".cool" }, highlighting);
+                    return highlighting;
+                }
+            }
+        }
+
+        public string GetIconPath(string iconPath)
+        {
+            if (CurrentTheme == Theme.Dark)
+            {
+                string darkIconPath = Path.Combine(Path.GetDirectoryName(iconPath) ?? "", 
+                    Path.GetFileNameWithoutExtension(iconPath) + ".dark" + Path.GetExtension(iconPath));
+                
+                if (File.Exists(darkIconPath))
+                {
+                    return darkIconPath;
+                }
+            }
+            return iconPath;
+        }
+
+        public string GetIconResourceName(string resourceName)
+        {
+            if (CurrentTheme == Theme.Dark)
+            {
+                string withoutExtension = resourceName.Substring(0, resourceName.LastIndexOf('.'));
+                string extension = resourceName.Substring(resourceName.LastIndexOf('.'));
+                string darkResourceName = withoutExtension + ".dark" + extension;
+                
+                return darkResourceName;
+            }
+            return resourceName;
+        }
+    }
+}

--- a/RevitPythonShell/Resources/Python-Dark.xshd
+++ b/RevitPythonShell/Resources/Python-Dark.xshd
@@ -1,0 +1,110 @@
+<SyntaxDefinition name="Python-Dark" extensions=".py">
+
+  <Properties>
+    <Property name="LineComment" value="#"/>
+  </Properties>
+
+  <Digits name="Digits" color="#B5CEA8"/>
+
+  <RuleSets>
+    <RuleSet ignorecase="false">
+
+      <Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
+
+      <Span name="DocComment" color="#6A9955">
+        <Begin>"""</Begin>
+        <End>"""</End>
+      </Span>
+
+      <Span name="SingleQuoteDocComment" color="#6A9955">
+        <Begin>'''</Begin>
+        <End>'''</End>
+      </Span>
+
+      <Span name="LineComment" stopateol="true" color="#6A9955">
+        <Begin>#</Begin>
+      </Span>
+
+      <Span name="String" stopateol="true" color="#CE9178" escapecharacter="\">
+        <Begin>"</Begin>
+        <End>"</End>
+      </Span>
+
+      <Span name="Char" stopateol="true" color="#CE9178" escapecharacter="\">
+        <Begin>'</Begin>
+        <End>'</End>
+      </Span>
+
+      <MarkPrevious bold="true" color="#DCDCAA">(</MarkPrevious>
+
+      <KeyWords name="Prompt" color="#4EC9B0" bold="true">
+        <Key word=">>>"/>
+        <Key word="..."/>
+      </KeyWords>
+
+      <KeyWords name="BuiltInStatements" bold="true" color="#C586C0">
+        <Key word="assert"/>
+        <Key word="del"/>
+        <Key word="exec"/>
+        <Key word="global"/>
+        <Key word="lambda"/>
+        <Key word="print"/>
+      </KeyWords>
+
+      <KeyWords name="ClassStatement" color="#569CD6" bold="true">
+        <Key word="class"/>
+      </KeyWords>
+
+      <KeyWords name="ExceptionHandlingStatements" bold="true" color="#C586C0">
+        <Key word="except"/>
+        <Key word="finally"/>
+        <Key word="raise"/>
+        <Key word="try"/>
+      </KeyWords>
+
+      <KeyWords name="FunctionDefinition" bold="true" color="#569CD6">
+        <Key word="def"/>
+      </KeyWords>
+
+      <KeyWords name="Imports" bold="true" color="#C586C0">
+        <Key word="import"/>
+        <Key word="from"/>
+      </KeyWords>
+
+      <KeyWords name="IterationStatements" bold="true" color="#569CD6">
+        <Key word="for"/>
+        <Key word="in"/>
+        <Key word="while"/>
+      </KeyWords>
+
+      <KeyWords name="JumpStatements" color="#C586C0">
+        <Key word="break"/>
+        <Key word="continue"/>
+        <Key word="yield"/>
+        <Key word="return"/>
+      </KeyWords>
+
+      <KeyWords name="OperatorStatements" bold="true" color="#569CD6">
+        <Key word="and"/>
+        <Key word="as"/>
+        <Key word="is"/>
+        <Key word="not"/>
+        <Key word="or"/>
+      </KeyWords>
+
+      <KeyWords name="PassStatement" color="#808080">
+        <Key word="pass"/>
+      </KeyWords>
+
+      <KeyWords name="SelectionStatements" bold="true" color="#569CD6">
+        <Key word="elif"/>
+        <Key word="else"/>
+        <Key word="if"/>
+      </KeyWords>
+
+      <KeyWords name="WithStatement" color="#4EC9B0">
+        <Key word="with"/>
+      </KeyWords>
+    </RuleSet>
+  </RuleSets>
+</SyntaxDefinition>

--- a/RevitPythonShell/Resources/Python-Dark.xshd
+++ b/RevitPythonShell/Resources/Python-Dark.xshd
@@ -1,110 +1,109 @@
-<SyntaxDefinition name="Python-Dark" extensions=".py">
+<?xml version="1.0"?>
+<SyntaxDefinition name="Python-Dark" extensions=".py"
+                  xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 
-  <Properties>
-    <Property name="LineComment" value="#"/>
-  </Properties>
+  <Color name="Comment" foreground="#7EC699" />
+  <Color name="String" foreground="#D7BA7D" />
+  <Color name="Char" foreground="#D7BA7D" />
+  <Color name="Digits" foreground="#B5CEA8" />
+  <Color name="Prompt" foreground="#9CDCFE" fontWeight="bold" />
+  <Color name="Keywords" foreground="#569CD6" fontWeight="bold" />
+  <Color name="ControlFlow" foreground="#C586C0" fontWeight="bold" />
+  <Color name="ClassName" foreground="#4EC9B0" fontWeight="bold" />
+  <Color name="FunctionDef" foreground="#DCDCAA" fontWeight="bold" />
+  <Color name="Exception" foreground="#F48771" fontWeight="bold" />
+  <Color name="MethodCall" foreground="#DCDCAA" fontWeight="bold" />
 
-  <Digits name="Digits" color="#B5CEA8"/>
+  <RuleSet ignoreCase="false">
 
-  <RuleSets>
-    <RuleSet ignorecase="false">
+    <Span color="Comment" multiline="true">
+      <Begin>"""</Begin>
+      <End>"""</End>
+    </Span>
 
-      <Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
+    <Span color="Comment" multiline="true">
+      <Begin>'''</Begin>
+      <End>'''</End>
+    </Span>
 
-      <Span name="DocComment" color="#6A9955">
-        <Begin>"""</Begin>
-        <End>"""</End>
-      </Span>
+    <Span color="Comment">
+      <Begin>\#</Begin>
+    </Span>
 
-      <Span name="SingleQuoteDocComment" color="#6A9955">
-        <Begin>'''</Begin>
-        <End>'''</End>
-      </Span>
+    <Span color="String">
+      <Begin>"</Begin>
+      <End>"</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="LineComment" stopateol="true" color="#6A9955">
-        <Begin>#</Begin>
-      </Span>
+    <Span color="Char">
+      <Begin>'</Begin>
+      <End>'</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="String" stopateol="true" color="#CE9178" escapecharacter="\">
-        <Begin>"</Begin>
-        <End>"</End>
-      </Span>
+    <Keywords color="Prompt">
+      <Word>&gt;&gt;&gt;</Word>
+      <Word>...</Word>
+    </Keywords>
 
-      <Span name="Char" stopateol="true" color="#CE9178" escapecharacter="\">
-        <Begin>'</Begin>
-        <End>'</End>
-      </Span>
+    <Keywords color="Keywords">
+      <Word>and</Word>
+      <Word>as</Word>
+      <Word>assert</Word>
+      <Word>del</Word>
+      <Word>exec</Word>
+      <Word>global</Word>
+      <Word>in</Word>
+      <Word>is</Word>
+      <Word>lambda</Word>
+      <Word>not</Word>
+      <Word>or</Word>
+      <Word>pass</Word>
+      <Word>print</Word>
+      <Word>with</Word>
+    </Keywords>
 
-      <MarkPrevious bold="true" color="#DCDCAA">(</MarkPrevious>
+    <Keywords color="ControlFlow">
+      <Word>break</Word>
+      <Word>continue</Word>
+      <Word>elif</Word>
+      <Word>else</Word>
+      <Word>for</Word>
+      <Word>if</Word>
+      <Word>return</Word>
+      <Word>while</Word>
+      <Word>yield</Word>
+      <Word>import</Word>
+      <Word>from</Word>
+    </Keywords>
 
-      <KeyWords name="Prompt" color="#4EC9B0" bold="true">
-        <Key word=">>>"/>
-        <Key word="..."/>
-      </KeyWords>
+    <Keywords color="ClassName">
+      <Word>class</Word>
+    </Keywords>
 
-      <KeyWords name="BuiltInStatements" bold="true" color="#C586C0">
-        <Key word="assert"/>
-        <Key word="del"/>
-        <Key word="exec"/>
-        <Key word="global"/>
-        <Key word="lambda"/>
-        <Key word="print"/>
-      </KeyWords>
+    <Keywords color="FunctionDef">
+      <Word>def</Word>
+    </Keywords>
 
-      <KeyWords name="ClassStatement" color="#569CD6" bold="true">
-        <Key word="class"/>
-      </KeyWords>
+    <Keywords color="Exception">
+      <Word>except</Word>
+      <Word>finally</Word>
+      <Word>raise</Word>
+      <Word>try</Word>
+    </Keywords>
 
-      <KeyWords name="ExceptionHandlingStatements" bold="true" color="#C586C0">
-        <Key word="except"/>
-        <Key word="finally"/>
-        <Key word="raise"/>
-        <Key word="try"/>
-      </KeyWords>
+    <Rule color="MethodCall">
+      \b[\w]+(?=\s*\()
+    </Rule>
 
-      <KeyWords name="FunctionDefinition" bold="true" color="#569CD6">
-        <Key word="def"/>
-      </KeyWords>
+    <Rule color="Digits">
+      \b0[xX][0-9a-fA-F]+|\b(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?[jJ]?\b
+    </Rule>
 
-      <KeyWords name="Imports" bold="true" color="#C586C0">
-        <Key word="import"/>
-        <Key word="from"/>
-      </KeyWords>
-
-      <KeyWords name="IterationStatements" bold="true" color="#569CD6">
-        <Key word="for"/>
-        <Key word="in"/>
-        <Key word="while"/>
-      </KeyWords>
-
-      <KeyWords name="JumpStatements" color="#C586C0">
-        <Key word="break"/>
-        <Key word="continue"/>
-        <Key word="yield"/>
-        <Key word="return"/>
-      </KeyWords>
-
-      <KeyWords name="OperatorStatements" bold="true" color="#569CD6">
-        <Key word="and"/>
-        <Key word="as"/>
-        <Key word="is"/>
-        <Key word="not"/>
-        <Key word="or"/>
-      </KeyWords>
-
-      <KeyWords name="PassStatement" color="#808080">
-        <Key word="pass"/>
-      </KeyWords>
-
-      <KeyWords name="SelectionStatements" bold="true" color="#569CD6">
-        <Key word="elif"/>
-        <Key word="else"/>
-        <Key word="if"/>
-      </KeyWords>
-
-      <KeyWords name="WithStatement" color="#4EC9B0">
-        <Key word="with"/>
-      </KeyWords>
-    </RuleSet>
-  </RuleSets>
+  </RuleSet>
 </SyntaxDefinition>

--- a/RevitPythonShell/Resources/Python.xshd
+++ b/RevitPythonShell/Resources/Python.xshd
@@ -1,110 +1,117 @@
-﻿<SyntaxDefinition name="Python" extensions=".py">
+﻿<?xml version="1.0"?>
+<SyntaxDefinition name="Python" extensions=".py"
+                  xmlns="http://icsharpcode.net/sharpdevelop/syntaxdefinition/2008">
 
-  <Properties>
-    <Property name="LineComment" value="#"/>
-  </Properties>
+  <Color name="Comment" foreground="Green" />
+  <Color name="String" foreground="Blue" />
+  <Color name="Char" foreground="Magenta" />
+  <Color name="Digits" foreground="DarkBlue" />
+  <Color name="Prompt" foreground="Blue" fontWeight="bold" />
+  <Color name="Keywords" foreground="MidnightBlue" fontWeight="bold" />
+  <Color name="ControlFlow" foreground="Blue" fontWeight="bold" />
+  <Color name="ClassName" foreground="Blue" fontWeight="bold" />
+  <Color name="FunctionDef" foreground="Blue" fontWeight="bold" />
+  <Color name="Exception" foreground="Teal" fontWeight="bold" />
+  <Color name="MethodCall" foreground="MidnightBlue" fontWeight="bold" />
+  <Color name="Operators" foreground="DarkCyan" fontWeight="bold" />
+  <Color name="Imports" foreground="Green" fontWeight="bold" />
 
-  <Digits name="Digits" color="DarkBlue"/>
+  <RuleSet ignoreCase="false">
 
-  <RuleSets>
-    <RuleSet ignorecase="false">
+    <Span color="Comment" multiline="true">
+      <Begin>"""</Begin>
+      <End>"""</End>
+    </Span>
 
-      <Delimiters>()[]{}@,:.`=;+-*/% &amp;|^&gt;&lt;</Delimiters>
+    <Span color="Comment" multiline="true">
+      <Begin>'''</Begin>
+      <End>'''</End>
+    </Span>
 
-      <Span name="DocComment" color="Green">
-        <Begin>"""</Begin>
-        <End>"""</End>
-      </Span>
+    <Span color="Comment">
+      <Begin>\#</Begin>
+    </Span>
 
-      <Span name="SingleQuoteDocComment" color="Green">
-        <Begin>'''</Begin>
-        <End>'''</End>
-      </Span>
+    <Span color="String">
+      <Begin>"</Begin>
+      <End>"</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="LineComment" stopateol="true" color="Green">
-        <Begin>#</Begin>
-      </Span>
+    <Span color="Char">
+      <Begin>'</Begin>
+      <End>'</End>
+      <RuleSet>
+        <Span begin="\\" end="." />
+      </RuleSet>
+    </Span>
 
-      <Span name="String" stopateol="true" color="Blue" escapecharacter="\">
-        <Begin>"</Begin>
-        <End>"</End>
-      </Span>
+    <Keywords color="Prompt">
+      <Word>&gt;&gt;&gt;</Word>
+      <Word>...</Word>
+    </Keywords>
 
-      <Span name="Char" stopateol="true" color="Magenta" escapecharacter="\">
-        <Begin>'</Begin>
-        <End>'</End>
-      </Span>
+    <Keywords color="Keywords">
+      <Word>assert</Word>
+      <Word>del</Word>
+      <Word>exec</Word>
+      <Word>global</Word>
+      <Word>lambda</Word>
+      <Word>pass</Word>
+      <Word>print</Word>
+      <Word>with</Word>
+    </Keywords>
 
-      <MarkPrevious bold="true" color="MidnightBlue">(</MarkPrevious>
+    <Keywords color="Operators">
+      <Word>and</Word>
+      <Word>as</Word>
+      <Word>in</Word>
+      <Word>is</Word>
+      <Word>not</Word>
+      <Word>or</Word>
+    </Keywords>
 
-      <KeyWords name="Prompt" color="Blue" bold="true">
-        <Key word=">>>"/>
-        <Key word="..."/>
-      </KeyWords>
+    <Keywords color="ControlFlow">
+      <Word>break</Word>
+      <Word>continue</Word>
+      <Word>elif</Word>
+      <Word>else</Word>
+      <Word>for</Word>
+      <Word>if</Word>
+      <Word>return</Word>
+      <Word>while</Word>
+      <Word>yield</Word>
+    </Keywords>
 
-      <KeyWords name="BuiltInStatements" bold="true" color="MidnightBlue">
-        <Key word="assert"/>
-        <Key word="del"/>
-        <Key word="exec"/>
-        <Key word="global"/>
-        <Key word="lambda"/>
-        <Key word="print"/>
-      </KeyWords>
+    <Keywords color="Imports">
+      <Word>import</Word>
+      <Word>from</Word>
+    </Keywords>
 
-      <KeyWords name="ClassStatement" color="Blue" bold="true">
-        <Key word="class"/>
-      </KeyWords>
+    <Keywords color="ClassName">
+      <Word>class</Word>
+    </Keywords>
 
-      <KeyWords name="ExceptionHandlingStatements" bold="true" color="Teal">
-        <Key word="except"/>
-        <Key word="finally"/>
-        <Key word="raise"/>
-        <Key word="try"/>
-      </KeyWords>
+    <Keywords color="FunctionDef">
+      <Word>def</Word>
+    </Keywords>
 
-      <KeyWords name="FunctionDefinition" bold="true" color="Blue">
-        <Key word="def"/>
-      </KeyWords>
+    <Keywords color="Exception">
+      <Word>except</Word>
+      <Word>finally</Word>
+      <Word>raise</Word>
+      <Word>try</Word>
+    </Keywords>
 
-      <KeyWords name="Imports" bold="true" color="Green">
-        <Key word="import"/>
-        <Key word="from"/>
-      </KeyWords>
+    <Rule color="MethodCall">
+      \b[\w]+(?=\s*\()
+    </Rule>
 
-      <KeyWords name="IterationStatements" bold="true" color="Blue">
-        <Key word="for"/>
-        <Key word="in"/>
-        <Key word="while"/>
-      </KeyWords>
+    <Rule color="Digits">
+      \b0[xX][0-9a-fA-F]+|\b(\d+(\.\d+)?|\.\d+)([eE][+-]?\d+)?[jJ]?\b
+    </Rule>
 
-      <KeyWords name="JumpStatements" color="Navy">
-        <Key word="break"/>
-        <Key word="continue"/>
-        <Key word="yield"/>
-        <Key word="return"/>
-      </KeyWords>
-
-      <KeyWords name="OperatorStatements" bold="true" color="DarkCyan">
-        <Key word="and"/>
-        <Key word="as"/>
-        <Key word="is"/>
-        <Key word="not"/>
-        <Key word="or"/>
-      </KeyWords>
-
-      <KeyWords name="PassStatement" color="Gray">
-        <Key word="pass"/>
-      </KeyWords>
-
-      <KeyWords name="SelectionStatements" bold="true" color="Blue">
-        <Key word="elif"/>
-        <Key word="else"/>
-        <Key word="if"/>
-      </KeyWords>
-
-      <KeyWords name="WithStatement" color="DarkViolet">
-        <Key word="with"/>
-      </KeyWords>
-    </RuleSet>
-  </RuleSets>
+  </RuleSet>
 </SyntaxDefinition>

--- a/RevitPythonShell/RevitCommands/DeployRpsAddinCommand.cs
+++ b/RevitPythonShell/RevitCommands/DeployRpsAddinCommand.cs
@@ -342,17 +342,11 @@ namespace RevitPythonShell.RevitCommands
             }
 
             // Create ResourceDescription list with proper lambda closures
-            var manifestResources = new List<ResourceDescription>();
-            foreach (var kvp in resourceData)
-            {
-                var name = kvp.Key;
-                var data = kvp.Key;
-                manifestResources.Add(new ResourceDescription(
-                    name,
-                    () => new MemoryStream(resourceData[data]),
-                    isPublic: true
-                ));
-            }
+            var manifestResources = resourceData.Select(kvp => new ResourceDescription(
+                kvp.Key,
+                () => new MemoryStream(kvp.Value),
+                isPublic: true
+            )).ToList();
 
             // Create compilation
             var compilation = CSharpCompilation.Create(

--- a/RevitPythonShell/RevitPythonShell.csproj
+++ b/RevitPythonShell/RevitPythonShell.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Configurations>Debug;Release</Configurations>
 		<RuntimeIdentifiers>win</RuntimeIdentifiers>
@@ -284,6 +284,7 @@
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="Helpers\ProcessManager.cs" />
+		<Compile Include="Helpers\ThemeManager.cs" />
 		<Compile Include="RevitCommands\CommandLoaderBase.cs" />
 		<Compile Include="Views\CompletionToolTip.cs" />
 		<Compile Include="RevitCommands\ConfigureCommand.cs" />
@@ -331,8 +332,8 @@
 		<Resource Include="Resources\Theme\Save.png" />
 		<Resource Include="Resources\Theme\Undo.png" />
 		<Resource Include="Resources\Theme\WordWrap.png" />
-		<EmbeddedResource Include="Resources\Console-16.png" />
-		<EmbeddedResource Include="Resources\Console-32.png" />
+		<Resource Include="Resources\Console-16.png" />
+		<Resource Include="Resources\Console-32.png" />
 		<EmbeddedResource Include="Resources\Deployment-16.png" />
 		<EmbeddedResource Include="Resources\Deployment-32.png" />
 		<EmbeddedResource Include="Resources\Python-16.png" />
@@ -358,6 +359,9 @@
 			<SubType>Designer</SubType>
 		</None>
 		<EmbeddedResource Include="Resources\Python.xshd" />
+		<EmbeddedResource Include="Resources\Python-Dark.xshd" />
+		<Resource Include="Themes\LightTheme.xaml" />
+		<Resource Include="Themes\DarkTheme.xaml" />
 	</ItemGroup>
 	<ItemGroup>
 		<Page Include="Views\IronPythonConsole.xaml">
@@ -416,14 +420,15 @@
 		<PropertyGroup>
 			<RootDir>bin\AddIn $(RevitVersion) $(Configuration)\</RootDir>
 			<AddinDir>$(RootDir)$(AssemblyName)\</AddinDir>
+			<RevitAddinsDir>$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\</RevitAddinsDir>
 		</PropertyGroup>
 
 		<Copy SourceFiles="@(RootItem)" DestinationFolder="$(RootDir)" />
 		<Copy SourceFiles="@(ConfigItem)" DestinationFolder="$(AddinDir)" />
 		<Copy SourceFiles="@(AddinItem)" DestinationFolder="$(AddinDir)" />
 
-		<Copy SourceFiles="@(RootItem)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))" />
-		<Copy SourceFiles="@(AddinItem)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))" />
-		<Copy SourceFiles="@(ConfigItem)" DestinationFolder="$(AppData)\Autodesk\Revit\Addins\$(RevitVersion)\$(AssemblyName)\%(RecursiveDir)" Condition="$(Configuration.Contains('Debug'))" />
+		<Copy SourceFiles="@(RootItem)" DestinationFolder="$(RevitAddinsDir)" Condition="$(Configuration.Contains('Debug'))" />
+		<Copy SourceFiles="@(AddinItem)" DestinationFolder="$(RevitAddinsDir)$(AssemblyName)\" Condition="$(Configuration.Contains('Debug'))" />
+		<Copy SourceFiles="@(ConfigItem)" DestinationFolder="$(RevitAddinsDir)$(AssemblyName)\" Condition="$(Configuration.Contains('Debug'))" />
 	</Target>
 </Project>

--- a/RevitPythonShell/RevitPythonShell.csproj
+++ b/RevitPythonShell/RevitPythonShell.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<Configurations>Debug;Release</Configurations>
 		<RuntimeIdentifiers>win</RuntimeIdentifiers>
@@ -264,6 +264,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="AvalonEdit" Version="6.3.0.90" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="none" />
 	</ItemGroup>
 	<ItemGroup>
 		<Reference Include="IronPython">

--- a/RevitPythonShell/Themes/DarkTheme.xaml
+++ b/RevitPythonShell/Themes/DarkTheme.xaml
@@ -1,0 +1,236 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
+    
+    <SolidColorBrush x:Key="ThemeWindowBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="ThemeWindowForeground" Color="#D4D4D4" />
+    
+    <SolidColorBrush x:Key="ThemeEditorBackground" Color="#141414" />
+    <SolidColorBrush x:Key="ThemeEditorForeground" Color="#DCDCDC" />
+    <SolidColorBrush x:Key="ThemeEditorSelection" Color="#1F3B5B" />
+    <SolidColorBrush x:Key="ThemeEditorSelectionBorder" Color="#0063B1" />
+
+    
+    <SolidColorBrush x:Key="ThemeRibbonBackground" Color="#141414" />
+    <SolidColorBrush x:Key="ThemeRibbonForeground" Color="#D4D4D4" />
+    <SolidColorBrush x:Key="ThemeRibbonBorder" Color="#2D2D30" />
+    
+    <SolidColorBrush x:Key="ThemePanelBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="ThemePanelBorder" Color="#3E3E42" />
+    
+    <SolidColorBrush x:Key="ThemeConsoleBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="ThemeConsoleForeground" Color="#D4D4D4" />
+    
+    <SolidColorBrush x:Key="ThemeGridSplitter" Color="#3E3E42" />
+    <SolidColorBrush x:Key="ThemeGridSplitterHover" Color="#007ACC" />
+    
+    <SolidColorBrush x:Key="ThemeLineNumbersForeground" Color="#7A7A7A" />
+    <SolidColorBrush x:Key="ThemeLineNumbersBackground" Color="#141414" />
+
+    
+    <SolidColorBrush x:Key="ThemeCaret" Color="#D4D4D4" />
+
+    <SolidColorBrush x:Key="ThemeTitleBarBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="ThemeTitleBarForeground" Color="#D4D4D4" />
+    <SolidColorBrush x:Key="ThemeTitleBarBorder" Color="#2D2D30" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonHover" Color="#3E3E42" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonPressed" Color="#505050" />
+    <SolidColorBrush x:Key="ThemeTitleBarCloseHover" Color="#C42B1C" />
+    <SolidColorBrush x:Key="ThemeTitleBarClosePressed" Color="#A31B10" />
+    <SolidColorBrush x:Key="ThemeTitleBarCloseForeground" Color="#FFFFFF" />
+
+    <SolidColorBrush x:Key="ThemeScrollBarBackground" Color="#2D2D30" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumb" Color="#3E3E42" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbHover" Color="#505050" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbPressed" Color="#606060" />
+    
+    <Color x:Key="ThemeHyperlink">#4EC9B0</Color>
+    <Color x:Key="ThemeHyperlinkHover">#007ACC</Color>
+    
+    <Style TargetType="{x:Type TextBlock}">
+        <Setter Property="Foreground" Value="{StaticResource ThemeWindowForeground}" />
+    </Style>
+
+    <Style TargetType="{x:Type ScrollViewer}">
+        <Setter Property="Background" Value="{StaticResource ThemeEditorBackground}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollViewer}">
+                    <Grid Background="{TemplateBinding Background}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <ScrollContentPresenter Grid.Row="0" Grid.Column="0"
+                                                Margin="{TemplateBinding Padding}"
+                                                Content="{TemplateBinding Content}"
+                                                ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                CanContentScroll="{TemplateBinding CanContentScroll}" />
+                        <ScrollBar x:Name="PART_VerticalScrollBar"
+                                   Grid.Row="0"
+                                   Grid.Column="1"
+                                   Orientation="Vertical"
+                                   Maximum="{TemplateBinding ScrollableHeight}"
+                                   ViewportSize="{TemplateBinding ViewportHeight}"
+                                   Value="{TemplateBinding VerticalOffset}"
+                                   Visibility="{TemplateBinding ComputedVerticalScrollBarVisibility}" />
+                        <ScrollBar x:Name="PART_HorizontalScrollBar"
+                                   Grid.Row="1"
+                                   Grid.Column="0"
+                                   Orientation="Horizontal"
+                                   Maximum="{TemplateBinding ScrollableWidth}"
+                                   ViewportSize="{TemplateBinding ViewportWidth}"
+                                   Value="{TemplateBinding HorizontalOffset}"
+                                   Visibility="{TemplateBinding ComputedHorizontalScrollBarVisibility}" />
+                        <Border Grid.Row="1"
+                                Grid.Column="1"
+                                Background="{StaticResource ThemeScrollBarBackground}" />
+                    </Grid>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type ScrollBar}">
+        <Setter Property="Background" Value="{StaticResource ThemeScrollBarBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource ThemeWindowForeground}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarBackground}" />
+        <Setter Property="MinWidth" Value="14" />
+        <Setter Property="MinHeight" Value="14" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type ScrollBar}">
+                    <ControlTemplate.Resources>
+                        <Style x:Key="ScrollBarArrowButtonStyle" TargetType="{x:Type RepeatButton}">
+                            <Setter Property="Background" Value="{StaticResource ThemeScrollBarBackground}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarBackground}" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Focusable" Value="False" />
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="{x:Type RepeatButton}">
+                                        <Border Background="{TemplateBinding Background}"
+                                                BorderBrush="{TemplateBinding BorderBrush}"
+                                                BorderThickness="{TemplateBinding BorderThickness}">
+                                            <Viewbox Width="8" Height="8" HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <Path x:Name="Arrow" Fill="{StaticResource ThemeWindowForeground}" Stretch="Uniform"
+                                                      Data="M 0 4 L 4 0 L 8 4 Z" />
+                                            </Viewbox>
+                                        </Border>
+                                        <ControlTemplate.Triggers>
+                                            <Trigger Property="Tag" Value="Down">
+                                                <Setter TargetName="Arrow" Property="Data" Value="M 0 0 L 4 4 L 8 0 Z" />
+                                            </Trigger>
+                                            <Trigger Property="Tag" Value="Left">
+                                                <Setter TargetName="Arrow" Property="Data" Value="M 4 0 L 0 4 L 4 8 Z" />
+                                            </Trigger>
+                                            <Trigger Property="Tag" Value="Right">
+                                                <Setter TargetName="Arrow" Property="Data" Value="M 0 0 L 4 4 L 0 8 Z" />
+                                            </Trigger>
+                                        </ControlTemplate.Triggers>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                        <Style x:Key="ScrollBarPageButtonStyle" TargetType="{x:Type RepeatButton}">
+                            <Setter Property="Background" Value="{StaticResource ThemeScrollBarBackground}" />
+                            <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarBackground}" />
+                            <Setter Property="BorderThickness" Value="0" />
+                            <Setter Property="Focusable" Value="False" />
+                        </Style>
+                    </ControlTemplate.Resources>
+                    <Grid x:Name="Root" Background="{TemplateBinding Background}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <RepeatButton x:Name="LineUpButton"
+                                      Grid.Row="0"
+                                      Grid.Column="1"
+                                      Width="14"
+                                      Height="14"
+                                      Tag="Up"
+                                      Command="{x:Static primitives:ScrollBar.LineUpCommand}"
+                                      Style="{StaticResource ScrollBarArrowButtonStyle}" />
+                        <Track x:Name="PART_Track"
+                               Grid.Row="1"
+                               Grid.Column="1"
+                               Maximum="{TemplateBinding Maximum}"
+                               Minimum="{TemplateBinding Minimum}"
+                               Value="{TemplateBinding Value}"
+                               ViewportSize="{TemplateBinding ViewportSize}"
+                               Orientation="{TemplateBinding Orientation}">
+                            <Track.DecreaseRepeatButton>
+                                <RepeatButton x:Name="PageUpButton"
+                                              Command="{x:Static primitives:ScrollBar.PageUpCommand}"
+                                              Style="{StaticResource ScrollBarPageButtonStyle}" />
+                            </Track.DecreaseRepeatButton>
+                            <Track.Thumb>
+                                <Thumb Background="{StaticResource ThemeScrollBarThumb}"
+                                       BorderBrush="{StaticResource ThemeScrollBarThumb}"
+                                       BorderThickness="1" />
+                            </Track.Thumb>
+                            <Track.IncreaseRepeatButton>
+                                <RepeatButton x:Name="PageDownButton"
+                                              Command="{x:Static primitives:ScrollBar.PageDownCommand}"
+                                              Style="{StaticResource ScrollBarPageButtonStyle}" />
+                            </Track.IncreaseRepeatButton>
+                        </Track>
+                        <RepeatButton x:Name="LineDownButton"
+                                      Grid.Row="2"
+                                      Grid.Column="1"
+                                      Width="14"
+                                      Height="14"
+                                      Tag="Down"
+                                      Command="{x:Static primitives:ScrollBar.LineDownCommand}"
+                                      Style="{StaticResource ScrollBarArrowButtonStyle}" />
+                    </Grid>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="Orientation" Value="Horizontal">
+                            <Setter TargetName="LineUpButton" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="LineUpButton" Property="Grid.Column" Value="0" />
+                            <Setter TargetName="LineDownButton" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="LineDownButton" Property="Grid.Column" Value="2" />
+                            <Setter TargetName="LineUpButton" Property="Tag" Value="Left" />
+                            <Setter TargetName="LineDownButton" Property="Tag" Value="Right" />
+                            <Setter TargetName="LineUpButton" Property="Command" Value="{x:Static ScrollBar.LineLeftCommand}" />
+                            <Setter TargetName="LineDownButton" Property="Command" Value="{x:Static ScrollBar.LineRightCommand}" />
+                            <Setter TargetName="PageUpButton" Property="Command" Value="{x:Static ScrollBar.PageLeftCommand}" />
+                            <Setter TargetName="PageDownButton" Property="Command" Value="{x:Static ScrollBar.PageRightCommand}" />
+                            <Setter TargetName="PART_Track" Property="Grid.Row" Value="1" />
+                            <Setter TargetName="PART_Track" Property="Grid.Column" Value="1" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style TargetType="{x:Type Thumb}">
+        <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumb}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumb}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumbHover}" />
+                <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumbHover}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+                <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumbPressed}" />
+                <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumbPressed}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    
+</ResourceDictionary>
+

--- a/RevitPythonShell/Themes/DarkTheme.xaml
+++ b/RevitPythonShell/Themes/DarkTheme.xaml
@@ -1,4 +1,4 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
 
@@ -298,6 +298,7 @@
                     <Setter Property="BorderThickness" Value="0" />
                     <Setter Property="Padding" Value="2,0" />
                     <Setter Property="MinHeight" Value="22" />
+                    <Setter Property="VerticalAlignment" Value="Center" />
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="{x:Type RibbonButton}">
@@ -307,7 +308,8 @@
                                         BorderThickness="{TemplateBinding BorderThickness}"
                                         CornerRadius="2"
                                         Padding="{TemplateBinding Padding}"
-                                            SnapsToDevicePixels="True">
+                                        SnapsToDevicePixels="True"
+                                        VerticalAlignment="{TemplateBinding VerticalAlignment}">
                                         <Grid>
                                             <Grid.RowDefinitions>
                                                 <RowDefinition Height="Auto" />

--- a/RevitPythonShell/Themes/DarkTheme.xaml
+++ b/RevitPythonShell/Themes/DarkTheme.xaml
@@ -1,52 +1,53 @@
-<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:primitives="clr-namespace:System.Windows.Controls.Primitives;assembly=PresentationFramework">
-    
-    <SolidColorBrush x:Key="ThemeWindowBackground" Color="#1E1E1E" />
+
+    <!-- Revit Dark Theme Colors -->
+    <SolidColorBrush x:Key="ThemeWindowBackground" Color="#2C3E50" />
     <SolidColorBrush x:Key="ThemeWindowForeground" Color="#D4D4D4" />
-    
-    <SolidColorBrush x:Key="ThemeEditorBackground" Color="#141414" />
+
+    <SolidColorBrush x:Key="ThemeEditorBackground" Color="#1F2D3D" />
     <SolidColorBrush x:Key="ThemeEditorForeground" Color="#DCDCDC" />
-    <SolidColorBrush x:Key="ThemeEditorSelection" Color="#1F3B5B" />
-    <SolidColorBrush x:Key="ThemeEditorSelectionBorder" Color="#0063B1" />
+    <SolidColorBrush x:Key="ThemeEditorSelection" Color="#1F4F6F" />
+    <SolidColorBrush x:Key="ThemeEditorSelectionBorder" Color="#0078D4" />
 
-    
-    <SolidColorBrush x:Key="ThemeRibbonBackground" Color="#141414" />
+
+    <SolidColorBrush x:Key="ThemeRibbonBackground" Color="#2C3E50" />
     <SolidColorBrush x:Key="ThemeRibbonForeground" Color="#D4D4D4" />
-    <SolidColorBrush x:Key="ThemeRibbonBorder" Color="#2D2D30" />
-    
-    <SolidColorBrush x:Key="ThemePanelBackground" Color="#1E1E1E" />
-    <SolidColorBrush x:Key="ThemePanelBorder" Color="#3E3E42" />
-    
-    <SolidColorBrush x:Key="ThemeConsoleBackground" Color="#1E1E1E" />
-    <SolidColorBrush x:Key="ThemeConsoleForeground" Color="#D4D4D4" />
-    
-    <SolidColorBrush x:Key="ThemeGridSplitter" Color="#3E3E42" />
-    <SolidColorBrush x:Key="ThemeGridSplitterHover" Color="#007ACC" />
-    
-    <SolidColorBrush x:Key="ThemeLineNumbersForeground" Color="#7A7A7A" />
-    <SolidColorBrush x:Key="ThemeLineNumbersBackground" Color="#141414" />
+    <SolidColorBrush x:Key="ThemeRibbonBorder" Color="#3D4F61" />
 
-    
+    <SolidColorBrush x:Key="ThemePanelBackground" Color="#2C3E50" />
+    <SolidColorBrush x:Key="ThemePanelBorder" Color="#3D4F61" />
+
+    <SolidColorBrush x:Key="ThemeConsoleBackground" Color="#1F2D3D" />
+    <SolidColorBrush x:Key="ThemeConsoleForeground" Color="#D4D4D4" />
+
+    <SolidColorBrush x:Key="ThemeGridSplitter" Color="#3D4F61" />
+    <SolidColorBrush x:Key="ThemeGridSplitterHover" Color="#0078D4" />
+
+    <SolidColorBrush x:Key="ThemeLineNumbersForeground" Color="#7A8A9A" />
+    <SolidColorBrush x:Key="ThemeLineNumbersBackground" Color="#1F2D3D" />
+
+
     <SolidColorBrush x:Key="ThemeCaret" Color="#D4D4D4" />
 
-    <SolidColorBrush x:Key="ThemeTitleBarBackground" Color="#1E1E1E" />
+    <SolidColorBrush x:Key="ThemeTitleBarBackground" Color="#2C3E50" />
     <SolidColorBrush x:Key="ThemeTitleBarForeground" Color="#D4D4D4" />
-    <SolidColorBrush x:Key="ThemeTitleBarBorder" Color="#2D2D30" />
-    <SolidColorBrush x:Key="ThemeTitleBarButtonHover" Color="#3E3E42" />
-    <SolidColorBrush x:Key="ThemeTitleBarButtonPressed" Color="#505050" />
+    <SolidColorBrush x:Key="ThemeTitleBarBorder" Color="#3D4F61" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonHover" Color="#3D4F61" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonPressed" Color="#4D5F71" />
     <SolidColorBrush x:Key="ThemeTitleBarCloseHover" Color="#C42B1C" />
     <SolidColorBrush x:Key="ThemeTitleBarClosePressed" Color="#A31B10" />
     <SolidColorBrush x:Key="ThemeTitleBarCloseForeground" Color="#FFFFFF" />
 
-    <SolidColorBrush x:Key="ThemeScrollBarBackground" Color="#2D2D30" />
-    <SolidColorBrush x:Key="ThemeScrollBarThumb" Color="#3E3E42" />
-    <SolidColorBrush x:Key="ThemeScrollBarThumbHover" Color="#505050" />
-    <SolidColorBrush x:Key="ThemeScrollBarThumbPressed" Color="#606060" />
-    
+    <SolidColorBrush x:Key="ThemeScrollBarBackground" Color="#2C3E50" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumb" Color="#4D5F71" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbHover" Color="#5D6F81" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbPressed" Color="#6D7F91" />
+
     <Color x:Key="ThemeHyperlink">#4EC9B0</Color>
-    <Color x:Key="ThemeHyperlinkHover">#007ACC</Color>
-    
+    <Color x:Key="ThemeHyperlinkHover">#0078D4</Color>
+
     <Style TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="{StaticResource ThemeWindowForeground}" />
     </Style>
@@ -165,6 +166,7 @@
                         <Track x:Name="PART_Track"
                                Grid.Row="1"
                                Grid.Column="1"
+                               IsDirectionReversed="True"
                                Maximum="{TemplateBinding Maximum}"
                                Minimum="{TemplateBinding Minimum}"
                                Value="{TemplateBinding Value}"
@@ -209,6 +211,7 @@
                             <Setter TargetName="PageDownButton" Property="Command" Value="{x:Static ScrollBar.PageRightCommand}" />
                             <Setter TargetName="PART_Track" Property="Grid.Row" Value="1" />
                             <Setter TargetName="PART_Track" Property="Grid.Column" Value="1" />
+                            <Setter TargetName="PART_Track" Property="IsDirectionReversed" Value="False" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>
@@ -230,7 +233,344 @@
                 <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumbPressed}" />
             </Trigger>
         </Style.Triggers>
-    </Style>
-    
-</ResourceDictionary>
+         </Style>
+
+        <Style TargetType="{x:Type CheckBox}">
+            <Setter Property="Foreground" Value="{StaticResource ThemeWindowForeground}" />
+            <Setter Property="Background" Value="#1F2D3D" />
+            <Setter Property="BorderBrush" Value="#5A7188" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="Padding" Value="4,0,0,0" />
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="{x:Type CheckBox}">
+                        <BulletDecorator Background="Transparent" VerticalAlignment="Center">
+                            <BulletDecorator.Bullet>
+                                <Border x:Name="CheckBoxBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        Width="14"
+                                        Height="14"
+                                        CornerRadius="2">
+                                    <TextBlock x:Name="CheckMark"
+                                               Text="✓"
+                                               Foreground="#FFFFFF"
+                                               FontSize="12"
+                                               FontWeight="Bold"
+                                               TextAlignment="Center"
+                                               VerticalAlignment="Center"
+                                               Visibility="Collapsed" />
+                                </Border>
+                            </BulletDecorator.Bullet>
+                            <ContentPresenter Margin="{TemplateBinding Padding}"
+                                              VerticalAlignment="Center"
+                                              RecognizesAccessKey="True" />
+                        </BulletDecorator>
+                        <ControlTemplate.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter TargetName="CheckBoxBorder" Property="Background" Value="#2C3E50" />
+                                <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="#6A8198" />
+                            </Trigger>
+                            <Trigger Property="IsPressed" Value="True">
+                                <Setter TargetName="CheckBoxBorder" Property="Background" Value="#1F4F6F" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+                                <Setter TargetName="CheckBoxBorder" Property="Background" Value="#0078D4" />
+                                <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="#0078D4" />
+                            </Trigger>
+                            <Trigger Property="IsEnabled" Value="False">
+                                <Setter Property="Opacity" Value="0.56" />
+                            </Trigger>
+                        </ControlTemplate.Triggers>
+                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+
+                <!-- RibbonButton Style for Dark Theme with Full Template Override -->
+                <Style TargetType="{x:Type RibbonButton}">
+                    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                    <Setter Property="Foreground" Value="{StaticResource ThemeRibbonForeground}" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="0" />
+                    <Setter Property="Padding" Value="2,0" />
+                    <Setter Property="MinHeight" Value="22" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type RibbonButton}">
+                                <Border x:Name="OuterBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="2"
+                                        Padding="{TemplateBinding Padding}"
+                                            SnapsToDevicePixels="True">
+                                        <Grid>
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="Auto" />
+                                                <RowDefinition Height="Auto" />
+                                            </Grid.RowDefinitions>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <!-- Large Image for LargeImageSource (shown by default when set) -->
+                                            <Image x:Name="LargeImage"
+                                                   Grid.Row="0"
+                                                   Grid.Column="0"
+                                                   Grid.ColumnSpan="2"
+                                                   Source="{TemplateBinding LargeImageSource}"
+                                                   Width="32"
+                                                   Height="32"
+                                                   Stretch="Uniform"
+                                                   Margin="0"
+                                                   HorizontalAlignment="Center"
+                                                   Visibility="Visible" />
+
+                                            <!-- Small Image for SmallImageSource -->
+                                            <Image x:Name="SmallImage"
+                                                   Grid.Row="0"
+                                                   Grid.Column="0"
+                                                   Source="{TemplateBinding SmallImageSource}"
+                                                   Width="16"
+                                                   Height="16"
+                                                   Stretch="Uniform"
+                                                   Margin="0,0,2,0"
+                                                   VerticalAlignment="Center"
+                                                   Visibility="Collapsed" />
+
+                                            <!-- Label -->
+                                            <TextBlock x:Name="LabelText"
+                                                       Grid.Row="1"
+                                                       Grid.Column="0"
+                                                       Grid.ColumnSpan="2"
+                                                       Text="{TemplateBinding Label}"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                   FontSize="11"
+                                                   HorizontalAlignment="Center"
+                                                   TextAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="NoWrap"
+                                                   Margin="0,0,0,0" />
+                                    </Grid>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <!-- When LargeImageSource IS null, show small image with horizontal layout -->
+                                    <Trigger Property="LargeImageSource" Value="{x:Null}">
+                                        <Setter TargetName="LargeImage" Property="Visibility" Value="Collapsed" />
+                                        <Setter TargetName="SmallImage" Property="Visibility" Value="Visible" />
+                                        <Setter TargetName="SmallImage" Property="Grid.Row" Value="0" />
+                                        <Setter TargetName="SmallImage" Property="Grid.Column" Value="0" />
+                                        <Setter TargetName="LabelText" Property="Grid.Row" Value="0" />
+                                        <Setter TargetName="LabelText" Property="Grid.Column" Value="1" />
+                                        <Setter TargetName="LabelText" Property="Margin" Value="0,0,0,0" />
+                                        <Setter TargetName="LabelText" Property="VerticalAlignment" Value="Center" />
+                                        <Setter TargetName="LabelText" Property="HorizontalAlignment" Value="Left" />
+                                    </Trigger>
+
+                                    <!-- Hover state -->
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#3D4F61" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#4D5F71" />
+                                    </Trigger>
+                                    <!-- Pressed state -->
+                                    <Trigger Property="IsPressed" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#2C3E50" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#3D4F61" />
+                                    </Trigger>
+                                    <!-- Disabled state -->
+                                    <Trigger Property="IsEnabled" Value="False">
+                                        <Setter Property="Opacity" Value="0.56" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+
+                <!-- RibbonToggleButton Style for Dark Theme -->
+                <Style TargetType="{x:Type RibbonToggleButton}">
+                    <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                    <Setter Property="Foreground" Value="{StaticResource ThemeRibbonForeground}" />
+                    <Setter Property="Background" Value="Transparent" />
+                    <Setter Property="BorderBrush" Value="Transparent" />
+                    <Setter Property="BorderThickness" Value="0" />
+                    <Setter Property="Padding" Value="2,0" />
+                    <Setter Property="MinHeight" Value="22" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type RibbonToggleButton}">
+                                <Border x:Name="OuterBorder"
+                                        Background="{TemplateBinding Background}"
+                                        BorderBrush="{TemplateBinding BorderBrush}"
+                                        BorderThickness="{TemplateBinding BorderThickness}"
+                                        CornerRadius="2"
+                                        Padding="{TemplateBinding Padding}"
+                                        SnapsToDevicePixels="True">
+                                    <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                                        <!-- Image -->
+                                        <Image x:Name="SmallImage"
+                                               Source="{TemplateBinding SmallImageSource}"
+                                               Width="16"
+                                               Height="16"
+                                               Stretch="Uniform"
+                                               Margin="0,0,2,0"
+                                               VerticalAlignment="Center" />
+                                        <!-- Label -->
+                                        <TextBlock x:Name="LabelText"
+                                                   Text="{TemplateBinding Label}"
+                                                   Foreground="{TemplateBinding Foreground}"
+                                                   FontSize="11"
+                                                   VerticalAlignment="Center"
+                                                   TextTrimming="CharacterEllipsis"
+                                                   TextWrapping="NoWrap"
+                                                   Margin="0" />
+                                    </StackPanel>
+                                </Border>
+                                <ControlTemplate.Triggers>
+                                    <!-- Hover state -->
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#3D4F61" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#4D5F71" />
+                                    </Trigger>
+                                    <!-- Pressed state -->
+                                    <Trigger Property="IsPressed" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#2C3E50" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#3D4F61" />
+                                    </Trigger>
+                                    <!-- Checked state -->
+                                    <Trigger Property="IsChecked" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#1F4F6F" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#0078D4" />
+                                    </Trigger>
+                                    <!-- Disabled state -->
+                                    <Trigger Property="IsEnabled" Value="False">
+                                        <Setter Property="Opacity" Value="0.56" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+
+                                    <!-- Custom RibbonCheckBox Style for Dark Theme -->
+                                    <Style TargetType="{x:Type RibbonCheckBox}">
+                                <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                                <Setter Property="Foreground" Value="{StaticResource ThemeRibbonForeground}" />
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="BorderBrush" Value="Transparent" />
+                                <Setter Property="BorderThickness" Value="0" />
+                                <Setter Property="Padding" Value="2,0" />
+                    <Setter Property="Template">
+                        <Setter.Value>
+                            <ControlTemplate TargetType="{x:Type RibbonCheckBox}">
+                                <Grid x:Name="MainGrid" SnapsToDevicePixels="True">
+                                    <Border x:Name="OuterBorder"
+                                            Background="{TemplateBinding Background}"
+                                            BorderBrush="{TemplateBinding BorderBrush}"
+                                            BorderThickness="{TemplateBinding BorderThickness}"
+                                            CornerRadius="2">
+                                        <Grid Margin="{TemplateBinding Padding}">
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+
+                                            <!-- Custom Dark Checkbox -->
+                                            <Border x:Name="CheckBoxBorder"
+                                                    Grid.Column="0"
+                                                    Background="#1F2D3D"
+                                                    BorderBrush="#5A7188"
+                                                    BorderThickness="1"
+                                                    Width="13"
+                                                    Height="13"
+                                                    Margin="0,0,0,0"
+                                                    CornerRadius="2"
+                                                    VerticalAlignment="Center"
+                                                    Visibility="Collapsed">
+                                                <Path x:Name="CheckMark"
+                                                      Data="M 0,3 L 2,5 L 5,0"
+                                                      Stroke="#FFFFFF"
+                                                      StrokeThickness="2"
+                                                      Stretch="Uniform"
+                                                      Width="8"
+                                                      Height="8"
+                                                      Visibility="Collapsed"
+                                                      VerticalAlignment="Center"
+                                                      HorizontalAlignment="Center" />
+                                            </Border>
+
+                                            <!-- Image (shown when SmallImageSource is set) -->
+                                            <Border x:Name="ImageBorder"
+                                                    Grid.Column="0"
+                                                    BorderThickness="2"
+                                                    BorderBrush="Transparent"
+                                                    CornerRadius="2"
+                                                    Padding="0"
+                                                    Margin="0,0,0,0"
+                                                    VerticalAlignment="Center">
+                                                <Image x:Name="SmallImage"
+                                                       Source="{TemplateBinding SmallImageSource}"
+                                                       Width="16"
+                                                       Height="16"
+                                                       Stretch="Uniform" />
+                                            </Border>
+
+                                            <!-- Label -->
+                                            <TextBlock x:Name="LabelText"
+                                                       Grid.Column="1"
+                                                       Text="{TemplateBinding Label}"
+                                                       Foreground="{TemplateBinding Foreground}"
+                                                       VerticalAlignment="Center"
+                                                       TextTrimming="CharacterEllipsis"
+                                                       TextWrapping="NoWrap"
+                                                       Margin="0,0,0,0" />
+                                        </Grid>
+                                    </Border>
+                                </Grid>
+                                <ControlTemplate.Triggers>
+                                    <!-- Show checkbox if no image is provided, otherwise show image -->
+                                    <Trigger Property="SmallImageSource" Value="{x:Null}">
+                                        <Setter TargetName="CheckBoxBorder" Property="Visibility" Value="Visible" />
+                                        <Setter TargetName="ImageBorder" Property="Visibility" Value="Collapsed" />
+                                    </Trigger>
+
+                                    <!-- Hover state -->
+                                    <Trigger Property="IsMouseOver" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#3D4F61" />
+                                        <Setter TargetName="OuterBorder" Property="BorderBrush" Value="#4D5F71" />
+                                        <Setter TargetName="CheckBoxBorder" Property="Background" Value="#2C3E50" />
+                                        <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="#6A8198" />
+                                    </Trigger>
+
+                                    <!-- Pressed state -->
+                                    <Trigger Property="IsPressed" Value="True">
+                                        <Setter TargetName="OuterBorder" Property="Background" Value="#2C3E50" />
+                                        <Setter TargetName="CheckBoxBorder" Property="Background" Value="#1F4F6F" />
+                                    </Trigger>
+
+                                    <!-- Checked state -->
+                                    <Trigger Property="IsChecked" Value="True">
+                                        <Setter TargetName="CheckMark" Property="Visibility" Value="Visible" />
+                                        <Setter TargetName="CheckBoxBorder" Property="Background" Value="#0078D4" />
+                                        <Setter TargetName="CheckBoxBorder" Property="BorderBrush" Value="#0078D4" />
+                                        <Setter TargetName="ImageBorder" Property="BorderBrush" Value="#0078D4" />
+                                        <Setter TargetName="ImageBorder" Property="Background" Value="#1F4F6F" />
+                                    </Trigger>
+
+                                    <!-- Disabled state -->
+                                    <Trigger Property="IsEnabled" Value="False">
+                                        <Setter Property="Opacity" Value="0.56" />
+                                    </Trigger>
+                                </ControlTemplate.Triggers>
+                            </ControlTemplate>
+                        </Setter.Value>
+                    </Setter>
+                </Style>
+
+                </ResourceDictionary>
 

--- a/RevitPythonShell/Themes/LightTheme.xaml
+++ b/RevitPythonShell/Themes/LightTheme.xaml
@@ -1,0 +1,74 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+    
+    <SolidColorBrush x:Key="ThemeWindowBackground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ThemeWindowForeground" Color="#000000" />
+    
+    <SolidColorBrush x:Key="ThemeEditorBackground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ThemeEditorForeground" Color="#000000" />
+    <SolidColorBrush x:Key="ThemeEditorSelection" Color="#ADD6FF" />
+    <SolidColorBrush x:Key="ThemeEditorSelectionBorder" Color="#007ACC" />
+    
+    <SolidColorBrush x:Key="ThemeRibbonBackground" Color="#F0F0F0" />
+    <SolidColorBrush x:Key="ThemeRibbonForeground" Color="#000000" />
+    <SolidColorBrush x:Key="ThemeRibbonBorder" Color="#D0D0D0" />
+    
+    <SolidColorBrush x:Key="ThemePanelBackground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ThemePanelBorder" Color="#E0E0E0" />
+    
+    <SolidColorBrush x:Key="ThemeConsoleBackground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ThemeConsoleForeground" Color="#000000" />
+    
+    <SolidColorBrush x:Key="ThemeGridSplitter" Color="#D0D0D0" />
+    <SolidColorBrush x:Key="ThemeGridSplitterHover" Color="#007ACC" />
+    
+    <SolidColorBrush x:Key="ThemeLineNumbersForeground" Color="#999999" />
+    <SolidColorBrush x:Key="ThemeLineNumbersBackground" Color="#FFFFFF" />
+    
+    <SolidColorBrush x:Key="ThemeCaret" Color="#000000" />
+
+    <SolidColorBrush x:Key="ThemeTitleBarBackground" Color="#FFFFFF" />
+    <SolidColorBrush x:Key="ThemeTitleBarForeground" Color="#000000" />
+    <SolidColorBrush x:Key="ThemeTitleBarBorder" Color="#D0D0D0" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonHover" Color="#E5E5E5" />
+    <SolidColorBrush x:Key="ThemeTitleBarButtonPressed" Color="#D5D5D5" />
+    <SolidColorBrush x:Key="ThemeTitleBarCloseHover" Color="#E81123" />
+    <SolidColorBrush x:Key="ThemeTitleBarClosePressed" Color="#C50F1F" />
+    <SolidColorBrush x:Key="ThemeTitleBarCloseForeground" Color="#FFFFFF" />
+
+    <SolidColorBrush x:Key="ThemeScrollBarBackground" Color="#E8E8E8" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumb" Color="#C2C2C2" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbHover" Color="#AFAFAF" />
+    <SolidColorBrush x:Key="ThemeScrollBarThumbPressed" Color="#9D9D9D" />
+    
+    <Color x:Key="ThemeHyperlink">#007ACC</Color>
+    <Color x:Key="ThemeHyperlinkHover">#005A9E</Color>
+    
+    <Style TargetType="{x:Type TextBlock}">
+        <Setter Property="Foreground" Value="{StaticResource ThemeWindowForeground}" />
+    </Style>
+
+    <Style TargetType="{x:Type ScrollBar}">
+        <Setter Property="Background" Value="{StaticResource ThemeScrollBarBackground}" />
+        <Setter Property="Foreground" Value="{StaticResource ThemeScrollBarThumb}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarBackground}" />
+    </Style>
+
+    <Style TargetType="{x:Type Thumb}">
+        <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumb}" />
+        <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumb}" />
+        <Setter Property="BorderThickness" Value="1" />
+        <Style.Triggers>
+            <Trigger Property="IsMouseOver" Value="True">
+                <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumbHover}" />
+                <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumbHover}" />
+            </Trigger>
+            <Trigger Property="IsDragging" Value="True">
+                <Setter Property="Background" Value="{StaticResource ThemeScrollBarThumbPressed}" />
+                <Setter Property="BorderBrush" Value="{StaticResource ThemeScrollBarThumbPressed}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+    
+</ResourceDictionary>
+

--- a/RevitPythonShell/Views/IronPythonConsole.xaml
+++ b/RevitPythonShell/Views/IronPythonConsole.xaml
@@ -25,8 +25,9 @@
 	<Window.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
-                <ResourceDictionary Source="/RevitPythonShell;component/Themes/DarkTheme.xaml" />
+                <!-- <ResourceDictionary Source="/RevitPythonShell;component/Themes/DarkTheme.xaml" /> -->
 
+                <ResourceDictionary Source="/RevitPythonShell;component/Themes/LightTheme.xaml" />
 			</ResourceDictionary.MergedDictionaries>
 
 			<Style TargetType="{x:Type Ribbon}">
@@ -83,6 +84,7 @@
 				<Setter Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
 				<Setter Property="Foreground" Value="{DynamicResource ThemeRibbonForeground}" />
 				<Setter Property="BorderBrush" Value="{DynamicResource ThemeRibbonBorder}" />
+				<Setter Property="Height" Value="78" />
 				<Setter Property="Template">
 					<Setter.Value>
 						<ControlTemplate TargetType="{x:Type RibbonGroup}">
@@ -163,9 +165,9 @@
 		<DockPanel Grid.Column="0" Grid.Row="1" Background="{DynamicResource ThemeRibbonBackground}">
 			<Ribbon Name="mainRibbon"
 					Margin="0,-22,0,0" 
-                    KeyboardNavigation.TabIndex="0"
-                    ContextMenu="{x:Null}"
-                    AllowDrop="False">
+					KeyboardNavigation.TabIndex="0"
+					ContextMenu="{x:Null}"
+					AllowDrop="False">
 				<Ribbon.Resources>
 					<Style TargetType="{x:Type Image}">
 						<Style.Triggers>
@@ -252,14 +254,6 @@
                                       Click="runClick"
                                       ToolTip="(F5) Run Script. Results will be displayed in the IronPython prompt." />
 					</RibbonGroup>
-					<RibbonGroup Header="Theme">
-						<RibbonButton Name="toggleThemeButton"
-                                      Label="Toggle&#10;Theme"
-
-                                      SnapsToDevicePixels="True"
-                                      Click="toggleThemeClick"
-                                      ToolTip="Toggle between Light and Dark theme" />
-					</RibbonGroup>
 				</RibbonTab>
 			</Ribbon>
 			<!-- <ToolBar DockPanel.Dock="Top"> -->
@@ -294,7 +288,7 @@
 		<Grid Grid.Row="4" MinHeight="20" Background="{DynamicResource ThemeConsoleBackground}">
 			<console:IronPythonConsoleControl Name="consoleControl" />
 		</Grid>
-		<Border Grid.Column="0" Grid.Row="0" Background="{DynamicResource ThemeTitleBarBackground}" BorderBrush="{DynamicResource ThemeTitleBarBorder}" BorderThickness="0,0,0,1">
+		<Border Grid.Column="0" Grid.Row="0" Panel.ZIndex="1" Background="{DynamicResource ThemeTitleBarBackground}" BorderBrush="{DynamicResource ThemeTitleBarBorder}" BorderThickness="0,0,0,1">
 			<Grid MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
 				<Grid.ColumnDefinitions>
 					<ColumnDefinition Width="Auto" />

--- a/RevitPythonShell/Views/IronPythonConsole.xaml
+++ b/RevitPythonShell/Views/IronPythonConsole.xaml
@@ -1,148 +1,316 @@
-﻿<Window
+<Window
     Height="600"
     MinHeight="400"
     MinWidth="300"
     Title="IronPython Console"
     Width="850"
+    Background="{DynamicResource ThemeWindowBackground}"
+    Foreground="{DynamicResource ThemeWindowForeground}"
+    WindowStyle="None"
+    ResizeMode="CanResize"
+    AllowsTransparency="False"
     x:Class="RevitPythonShell.Views.IronPythonConsole"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:avalonEdit="http://icsharpcode.net/sharpdevelop/avalonedit"
     xmlns:console="clr-namespace:PythonConsoleControl;assembly=PythonConsoleControl"
+    xmlns:shell="clr-namespace:System.Windows.Shell;assembly=PresentationFramework"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-    <!--
+	<!--
         Copyright (c) 2010 Joe Moorhouse
     -->
-    <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto" />
-            <RowDefinition Height="20*" />
-            <RowDefinition Height="10" />
-            <RowDefinition Height="12*" />
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*" />
-            <ColumnDefinition Width="Auto" />
-        </Grid.ColumnDefinitions>
-        <DockPanel Grid.Column="0" Grid.Row="0">
-            <Ribbon Margin="0,-22,0,0" 
+	<WindowChrome.WindowChrome>
+		<shell:WindowChrome CaptionHeight="0" ResizeBorderThickness="6" CornerRadius="0" GlassFrameThickness="0" UseAeroCaptionButtons="False" />
+	</WindowChrome.WindowChrome>
+
+	<Window.Resources>
+		<ResourceDictionary>
+			<ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="/RevitPythonShell;component/Themes/DarkTheme.xaml" />
+
+			</ResourceDictionary.MergedDictionaries>
+
+			<Style TargetType="{x:Type Ribbon}">
+				<Setter Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
+				<Setter Property="Foreground" Value="{DynamicResource ThemeRibbonForeground}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ThemeRibbonBorder}" />
+			</Style>
+
+			<Style TargetType="{x:Type RibbonTab}">
+				<Setter Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
+				<Setter Property="Foreground" Value="{DynamicResource ThemeRibbonForeground}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ThemeRibbonBorder}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type RibbonTab}">
+							<Border Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="0,0,0,1"
+									Padding="4">
+								<ItemsPresenter />
+							</Border>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+
+			<Style TargetType="{x:Type RibbonTabHeader}">
+				<Setter Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
+				<Setter Property="Foreground" Value="{DynamicResource ThemeRibbonForeground}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ThemeRibbonBorder}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type RibbonTabHeader}">
+							<Border x:Name="TabBorder"
+									Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="0,0,1,1"
+									Padding="8,2">
+								<ContentPresenter ContentSource="Content"
+										HorizontalAlignment="Center"
+										VerticalAlignment="Center" />
+							</Border>
+							<ControlTemplate.Triggers>
+								<Trigger Property="IsMouseOver" Value="True">
+									<Setter TargetName="TabBorder" Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
+								</Trigger>
+							</ControlTemplate.Triggers>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+
+			<Style TargetType="{x:Type RibbonGroup}">
+				<Setter Property="Background" Value="{DynamicResource ThemeRibbonBackground}" />
+				<Setter Property="Foreground" Value="{DynamicResource ThemeRibbonForeground}" />
+				<Setter Property="BorderBrush" Value="{DynamicResource ThemeRibbonBorder}" />
+				<Setter Property="Template">
+					<Setter.Value>
+						<ControlTemplate TargetType="{x:Type RibbonGroup}">
+							<Border Background="{TemplateBinding Background}"
+									BorderBrush="{TemplateBinding BorderBrush}"
+									BorderThickness="0,0,1,1"
+									Padding="4">
+								<DockPanel LastChildFill="True">
+									<ContentPresenter ContentSource="Header"
+											DockPanel.Dock="Bottom"
+											HorizontalAlignment="Center"
+											Margin="0,2,0,0" />
+									<ItemsPresenter />
+								</DockPanel>
+							</Border>
+						</ControlTemplate>
+					</Setter.Value>
+				</Setter>
+			</Style>
+
+			<Style TargetType="{x:Type GridSplitter}">
+				<Setter Property="Background" Value="{DynamicResource ThemeGridSplitter}" />
+				<Style.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ThemeGridSplitterHover}" />
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+
+			<Style x:Key="TitleBarButtonStyle" TargetType="{x:Type Button}">
+				<Setter Property="Background" Value="Transparent" />
+				<Setter Property="Foreground" Value="{DynamicResource ThemeTitleBarForeground}" />
+				<Setter Property="BorderThickness" Value="0" />
+				<Setter Property="Width" Value="46" />
+				<Setter Property="Height" Value="40" />
+				<Setter Property="FontFamily" Value="Segoe MDL2 Assets" />
+				<Setter Property="FontSize" Value="12" />
+				<Setter Property="Padding" Value="0" />
+				<Setter Property="HorizontalContentAlignment" Value="Center" />
+				<Setter Property="VerticalContentAlignment" Value="Center" />
+				<Style.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ThemeTitleBarButtonHover}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ThemeTitleBarButtonPressed}" />
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+
+			<Style x:Key="TitleBarCloseButtonStyle" TargetType="{x:Type Button}" BasedOn="{StaticResource TitleBarButtonStyle}">
+				<Style.Triggers>
+					<Trigger Property="IsMouseOver" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ThemeTitleBarCloseHover}" />
+						<Setter Property="Foreground" Value="{DynamicResource ThemeTitleBarCloseForeground}" />
+					</Trigger>
+					<Trigger Property="IsPressed" Value="True">
+						<Setter Property="Background" Value="{DynamicResource ThemeTitleBarClosePressed}" />
+						<Setter Property="Foreground" Value="{DynamicResource ThemeTitleBarCloseForeground}" />
+					</Trigger>
+				</Style.Triggers>
+			</Style>
+		</ResourceDictionary>
+	</Window.Resources>
+
+	<Grid Background="{DynamicResource ThemeWindowBackground}">
+		<Grid.RowDefinitions>
+			<RowDefinition Height="40" />
+			<RowDefinition Height="Auto" />
+			<RowDefinition Height="20*" />
+			<RowDefinition Height="10" />
+			<RowDefinition Height="12*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="1*" />
+			<ColumnDefinition Width="Auto" />
+		</Grid.ColumnDefinitions>
+		<DockPanel Grid.Column="0" Grid.Row="1" Background="{DynamicResource ThemeRibbonBackground}">
+			<Ribbon Name="mainRibbon"
+					Margin="0,-22,0,0" 
                     KeyboardNavigation.TabIndex="0"
                     ContextMenu="{x:Null}"
                     AllowDrop="False">
-                <Ribbon.Resources>
-                    <Style TargetType="{x:Type Image}">
-                        <Style.Triggers>
-                            <DataTrigger
+				<Ribbon.Resources>
+					<Style TargetType="{x:Type Image}">
+						<Style.Triggers>
+							<DataTrigger
                                 Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type ButtonBase}, AncestorLevel=1}, Path=IsEnabled}"
                                 Value="False">
-                                <Setter Property="Opacity" Value="0.30" />
-                            </DataTrigger>
-                        </Style.Triggers>
-                    </Style>
-                </Ribbon.Resources>
-                <Ribbon.ApplicationMenu>
-                    <RibbonApplicationMenu Visibility="Collapsed">
-                    </RibbonApplicationMenu>
-                </Ribbon.ApplicationMenu>
-                <RibbonTab Header="Home" ContextMenu="{x:Null}">
-                    <RibbonGroup Header="File">
-                        <RibbonButton Label="New" LargeImageSource="../Resources/Theme/New.png"
+								<Setter Property="Opacity" Value="0.30" />
+							</DataTrigger>
+						</Style.Triggers>
+					</Style>
+				</Ribbon.Resources>
+				<Ribbon.QuickAccessToolBar>
+					<RibbonQuickAccessToolBar Visibility="Collapsed" Height="0" MinHeight="0" />
+				</Ribbon.QuickAccessToolBar>
+				<Ribbon.ApplicationMenu>
+					<RibbonApplicationMenu Visibility="Collapsed">
+					</RibbonApplicationMenu>
+				</Ribbon.ApplicationMenu>
+				<RibbonTab Header="Home" ContextMenu="{x:Null}">
+					<RibbonGroup Header="File">
+						<RibbonButton Label="New" LargeImageSource="../Resources/Theme/New.png"
                                       ToolTip="New (Ctrl + N)"
                                       SnapsToDevicePixels="True"
                                      Click="newFileClick" />
-                        <RibbonButton Label="Open" LargeImageSource="../Resources/Theme/Open.png"
+						<RibbonButton Label="Open" LargeImageSource="../Resources/Theme/Open.png"
                                       ToolTip="Open (Ctrl + O)"
                                       Click="openFileClick" />
-                        <RibbonButton Label="Save" LargeImageSource="../Resources/Theme/Save.png"
+						<RibbonButton Label="Save" LargeImageSource="../Resources/Theme/Save.png"
                                       ToolTip="Save (Ctrl + S)"
                                       Click="saveFileClick"
                                       SnapsToDevicePixels="True" />
-                        <RibbonButton Label="Save As" LargeImageSource="../Resources/Theme/SaveAs.png"
+						<RibbonButton Label="Save As" LargeImageSource="../Resources/Theme/SaveAs.png"
                                       ToolTip="Save As (Ctrl + Shift + S)"
                                       SnapsToDevicePixels="True"
                                       Click="saveAsFileClick" />
-                    </RibbonGroup>
-                    <RibbonGroup Header="Modify">
-                        <RibbonButton Label="Cut" SmallImageSource="../Resources/Theme/Cut.png"
+					</RibbonGroup>
+					<RibbonGroup Header="Modify">
+						<RibbonButton Label="Cut" SmallImageSource="../Resources/Theme/Cut.png"
                                       ToolTip="Cut Selected"
                                       SnapsToDevicePixels="True"
                                       Command="Cut" />
-                        <RibbonButton Label="Copy" SmallImageSource="../Resources/Theme/Save.png"
+						<RibbonButton Label="Copy" SmallImageSource="../Resources/Theme/Save.png"
                                       ToolTip="Copy Selected"
                                       SnapsToDevicePixels="True"
                                       Command="Copy" />
-                        <RibbonButton Label="Paste" SmallImageSource="../Resources/Theme/Paste.png"
+						<RibbonButton Label="Paste" SmallImageSource="../Resources/Theme/Paste.png"
                                       ToolTip="Paste Into Script Editor"
                                       SnapsToDevicePixels="True"
                                       Command="Paste" />
-                    </RibbonGroup>
-                    <RibbonGroup Header="Edit">
-                        <RibbonToggleButton Label="Undo"
+					</RibbonGroup>
+					<RibbonGroup Header="Edit">
+						<RibbonToggleButton Label="Undo"
                                             SmallImageSource="../Resources/Theme/Undo.png"
                                             SnapsToDevicePixels="True"
                                             ToolTip="Undo"
                                             Command="Undo" />
-                        <RibbonButton Label="Redo" SmallImageSource="../Resources/Theme/Redo.png"
+						<RibbonButton Label="Redo" SmallImageSource="../Resources/Theme/Redo.png"
                                       ToolTip="Redo"
                                       SnapsToDevicePixels="True"
                                       Command="Redo" />
-                        <RibbonButton Label="Delete" SmallImageSource="../Resources/Theme/Delete.png"
+						<RibbonButton Label="Delete" SmallImageSource="../Resources/Theme/Delete.png"
                                       ToolTip="Delete Selected"
                                       SnapsToDevicePixels="True"
                                       Command="Delete" />
-                    </RibbonGroup>
-                    <RibbonGroup Header="Cell">
-                        <RibbonCheckBox Label="WordWrap" SmallImageSource="../Resources/Theme/WordWrap.png"
+					</RibbonGroup>
+					<RibbonGroup Header="Cell">
+						<RibbonCheckBox Label="WordWrap" SmallImageSource="../Resources/Theme/WordWrap.png"
                                         ToolTip="Toggle Word Wrap"
                                         SnapsToDevicePixels="True"
                                         IsChecked="{Binding ElementName=textEditor, Path=WordWrap}" />
-                        <RibbonCheckBox Label="Paragraph" SmallImageSource="../Resources/Theme/Paragraph.png"
+						<RibbonCheckBox Label="Paragraph" SmallImageSource="../Resources/Theme/Paragraph.png"
                                         ToolTip="Toggle Show End of Line"
                                         SnapsToDevicePixels="True"
                                         IsChecked="{Binding ElementName=textEditor, Path=Options.ShowEndOfLine}"
                                         />
-                        <RibbonCheckBox Label="Number" SmallImageSource="../Resources/Theme/Number.png"
+						<RibbonCheckBox Label="Number" SmallImageSource="../Resources/Theme/Number.png"
                                         IsChecked="{Binding ElementName=textEditor, Path=ShowLineNumbers}"
                                         ToolTip="Toggle Line Numbers"
                                         SnapsToDevicePixels="True"/>
-                    </RibbonGroup>
-                    <RibbonGroup Header="Execute">
-                        <RibbonButton Label="Run" LargeImageSource="../Resources/Theme/Run.png"
+					</RibbonGroup>
+					<RibbonGroup Header="Execute">
+						<RibbonButton Label="Run" LargeImageSource="../Resources/Theme/Run.png"
                                       SnapsToDevicePixels="True"
                                       Click="runClick"
                                       ToolTip="(F5) Run Script. Results will be displayed in the IronPython prompt." />
-                    </RibbonGroup>
-                </RibbonTab>
-            </Ribbon>
-            <!-- <ToolBar DockPanel.Dock="Top"> -->
-            <!--     <Separator /> -->
-            <!--     <CheckBox IsChecked="{Binding ElementName=textEditor, Path=ShowLineNumbers}"> -->
-            <!--         <Image -->
-            <!--             Height="16" -->
-            <!--             SnapsToDevicePixels="True" -->
-            <!--             Source="/RevitPythonShell;component/Resources/Theme/Number.png" -->
-            <!--             ToolTip="Toggle Line Numbers" /> -->
-            <!--     </CheckBox> -->
-            <!-- </ToolBar> -->
-        </DockPanel>
-        <Grid Grid.Column="0" Grid.Row="1">
-            <avalonEdit:TextEditor
+					</RibbonGroup>
+					<RibbonGroup Header="Theme">
+						<RibbonButton Name="toggleThemeButton"
+                                      Label="Toggle&#10;Theme"
+
+                                      SnapsToDevicePixels="True"
+                                      Click="toggleThemeClick"
+                                      ToolTip="Toggle between Light and Dark theme" />
+					</RibbonGroup>
+				</RibbonTab>
+			</Ribbon>
+			<!-- <ToolBar DockPanel.Dock="Top"> -->
+			<!--     <Separator /> -->
+			<!--     <CheckBox IsChecked="{Binding ElementName=textEditor, Path=ShowLineNumbers}"> -->
+			<!--         <Image -->
+			<!--             Height="16" -->
+			<!--             SnapsToDevicePixels="True" -->
+			<!--             Source="/RevitPythonShell;component/Resources/Theme/Number.png" -->
+			<!--             ToolTip="Toggle Line Numbers" /> -->
+			<!--     </CheckBox> -->
+			<!-- </ToolBar> -->
+		</DockPanel>
+		<Grid Grid.Column="0" Grid.Row="2" Background="{DynamicResource ThemeEditorBackground}">
+			<avalonEdit:TextEditor
                 FontFamily="Consolas"
                 FontSize="10pt"
+                Background="{DynamicResource ThemeEditorBackground}"
+                Foreground="{DynamicResource ThemeEditorForeground}"
                 GotFocus="textEditor_GotFocus"
                 Name="textEditor">
-                # IronPython Pad. Write code snippets here and F5 to run.
-            </avalonEdit:TextEditor>
-        </Grid>
-        <GridSplitter
-            Grid.Row="2"
+				# IronPython Pad. Write code snippets here and F5 to run.
+			</avalonEdit:TextEditor>
+		</Grid>
+		<GridSplitter
+            Grid.Row="3"
             Grid.Column="0"
             Height="10"
             HorizontalAlignment="Stretch"
             VerticalAlignment="Center" />
 
-        <Grid Grid.Row="3" MinHeight="20">
-            <console:IronPythonConsoleControl Name="consoleControl" />
-        </Grid>
+		<Grid Grid.Row="4" MinHeight="20" Background="{DynamicResource ThemeConsoleBackground}">
+			<console:IronPythonConsoleControl Name="consoleControl" />
+		</Grid>
+		<Border Grid.Column="0" Grid.Row="0" Background="{DynamicResource ThemeTitleBarBackground}" BorderBrush="{DynamicResource ThemeTitleBarBorder}" BorderThickness="0,0,0,1">
+			<Grid MouseLeftButtonDown="TitleBar_MouseLeftButtonDown">
+				<Grid.ColumnDefinitions>
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="*" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="Auto" />
+					<ColumnDefinition Width="Auto" />
+				</Grid.ColumnDefinitions>
+				<Image Source="/RevitPythonShell;component/Resources/Console-16.png" Width="16" Height="16" Margin="10,0,6,0" VerticalAlignment="Center" />
+				<TextBlock Grid.Column="1" VerticalAlignment="Center" Foreground="{DynamicResource ThemeTitleBarForeground}" Text="{Binding Title, RelativeSource={RelativeSource AncestorType={x:Type Window}}}" />
+				<Button Grid.Column="2" x:Name="minimizeButton" Style="{StaticResource TitleBarButtonStyle}" Click="MinimizeButton_Click" Content="&#xE921;" />
+				<Button Grid.Column="3" x:Name="maximizeButton" Style="{StaticResource TitleBarButtonStyle}" Click="MaximizeButton_Click" Content="&#xE922;" />
+				<Button Grid.Column="4" x:Name="closeButton" Style="{StaticResource TitleBarCloseButtonStyle}" Click="CloseButton_Click" Content="&#xE8BB;" />
+			</Grid>
+		</Border>
 
-    </Grid>
+
+	</Grid>
 </Window>

--- a/RevitPythonShell/Views/IronPythonConsole.xaml
+++ b/RevitPythonShell/Views/IronPythonConsole.xaml
@@ -25,9 +25,8 @@
 	<Window.Resources>
 		<ResourceDictionary>
 			<ResourceDictionary.MergedDictionaries>
-                <!-- <ResourceDictionary Source="/RevitPythonShell;component/Themes/DarkTheme.xaml" /> -->
-
-                <ResourceDictionary Source="/RevitPythonShell;component/Themes/LightTheme.xaml" />
+                <ResourceDictionary Source="/RevitPythonShell;component/Themes/DarkTheme.xaml" />
+                <!-- <ResourceDictionary Source="/RevitPythonShell;component/Themes/LightTheme.xaml" /> -->
 			</ResourceDictionary.MergedDictionaries>
 
 			<Style TargetType="{x:Type Ribbon}">
@@ -186,25 +185,25 @@
 					<RibbonApplicationMenu Visibility="Collapsed">
 					</RibbonApplicationMenu>
 				</Ribbon.ApplicationMenu>
-				<RibbonTab Header="Home" ContextMenu="{x:Null}">
-					<RibbonGroup Header="File">
+				<RibbonTab Header="Home" ContextMenu="{x:Null}" Height="90">
+					<RibbonGroup Header="File" Height="82">
 						<RibbonButton Label="New" LargeImageSource="../Resources/Theme/New.png"
                                       ToolTip="New (Ctrl + N)"
                                       SnapsToDevicePixels="True"
-                                     Click="newFileClick" />
+                                     Click="newFileClick" Margin="0,0,0,-11" />
 						<RibbonButton Label="Open" LargeImageSource="../Resources/Theme/Open.png"
                                       ToolTip="Open (Ctrl + O)"
-                                      Click="openFileClick" />
+                                      Click="openFileClick" Margin="0,0,0,-11" />
 						<RibbonButton Label="Save" LargeImageSource="../Resources/Theme/Save.png"
                                       ToolTip="Save (Ctrl + S)"
                                       Click="saveFileClick"
-                                      SnapsToDevicePixels="True" />
+                                      SnapsToDevicePixels="True" Margin="0,0,0,-11" />
 						<RibbonButton Label="Save As" LargeImageSource="../Resources/Theme/SaveAs.png"
                                       ToolTip="Save As (Ctrl + Shift + S)"
                                       SnapsToDevicePixels="True"
-                                      Click="saveAsFileClick" />
+                                      Click="saveAsFileClick" Margin="0,0,0,-11" Width="46" />
 					</RibbonGroup>
-					<RibbonGroup Header="Modify">
+					<RibbonGroup Header="Modify" Height="82">
 						<RibbonButton Label="Cut" SmallImageSource="../Resources/Theme/Cut.png"
                                       ToolTip="Cut Selected"
                                       SnapsToDevicePixels="True"
@@ -218,7 +217,7 @@
                                       SnapsToDevicePixels="True"
                                       Command="Paste" />
 					</RibbonGroup>
-					<RibbonGroup Header="Edit">
+					<RibbonGroup Header="Edit" Height="82">
 						<RibbonToggleButton Label="Undo"
                                             SmallImageSource="../Resources/Theme/Undo.png"
                                             SnapsToDevicePixels="True"
@@ -233,7 +232,7 @@
                                       SnapsToDevicePixels="True"
                                       Command="Delete" />
 					</RibbonGroup>
-					<RibbonGroup Header="Cell">
+					<RibbonGroup Header="Cell" Height="82">
 						<RibbonCheckBox Label="WordWrap" SmallImageSource="../Resources/Theme/WordWrap.png"
                                         ToolTip="Toggle Word Wrap"
                                         SnapsToDevicePixels="True"
@@ -248,7 +247,7 @@
                                         ToolTip="Toggle Line Numbers"
                                         SnapsToDevicePixels="True"/>
 					</RibbonGroup>
-					<RibbonGroup Header="Execute">
+					<RibbonGroup Header="Execute" Height="82">
 						<RibbonButton Label="Run" LargeImageSource="../Resources/Theme/Run.png"
                                       SnapsToDevicePixels="True"
                                       Click="runClick"
@@ -256,16 +255,6 @@
 					</RibbonGroup>
 				</RibbonTab>
 			</Ribbon>
-			<!-- <ToolBar DockPanel.Dock="Top"> -->
-			<!--     <Separator /> -->
-			<!--     <CheckBox IsChecked="{Binding ElementName=textEditor, Path=ShowLineNumbers}"> -->
-			<!--         <Image -->
-			<!--             Height="16" -->
-			<!--             SnapsToDevicePixels="True" -->
-			<!--             Source="/RevitPythonShell;component/Resources/Theme/Number.png" -->
-			<!--             ToolTip="Toggle Line Numbers" /> -->
-			<!--     </CheckBox> -->
-			<!-- </ToolBar> -->
 		</DockPanel>
 		<Grid Grid.Column="0" Grid.Row="2" Background="{DynamicResource ThemeEditorBackground}">
 			<avalonEdit:TextEditor
@@ -304,7 +293,5 @@
 				<Button Grid.Column="4" x:Name="closeButton" Style="{StaticResource TitleBarCloseButtonStyle}" Click="CloseButton_Click" Content="&#xE8BB;" />
 			</Grid>
 		</Border>
-
-
 	</Grid>
 </Window>

--- a/RevitPythonShell/Views/IronPythonConsole.xaml.cs
+++ b/RevitPythonShell/Views/IronPythonConsole.xaml.cs
@@ -103,7 +103,6 @@ namespace RevitPythonShell.Views
         }
  
         private void textEditor_PreviewKeyDown(object sender, KeyEventArgs e)
- 
         {
             if (e.Key == Key.F5) RunStatements();
             if (e.Key == Key.S && Keyboard.Modifiers == ModifierKeys.Control) SaveFile();
@@ -201,7 +200,6 @@ namespace RevitPythonShell.Views
         }
  
         // Clear the contents on first click inside the editor
-
         private void textEditor_GotFocus(object sender, RoutedEventArgs e)
         {
             if (this.currentFileName == null)

--- a/RevitPythonShell/Views/IronPythonConsole.xaml.cs
+++ b/RevitPythonShell/Views/IronPythonConsole.xaml.cs
@@ -28,6 +28,7 @@ namespace RevitPythonShell.Views
 
             var settings = App.GetSettings();
             ThemeManager.Instance.LoadThemeFromSettings(settings);
+            ThemeManager.Instance.ApplyRevitThemePreference();
             ApplyTheme();
             ThemeManager.Instance.ThemeChanged += ThemeManager_ThemeChanged;
 

--- a/RpsRuntime/ScriptExecutor.cs
+++ b/RpsRuntime/ScriptExecutor.cs
@@ -97,7 +97,7 @@ namespace RpsRuntime
                 try
                 {
                     script.Execute(scope);
-
+                    outputStream.Flush();
                     _message = (scope.GetVariable("__message__") ?? "").ToString();
                     return (int)(scope.GetVariable("__result__") ?? Result.Succeeded);
                 }

--- a/RpsRuntime/ScriptOutputStream.cs
+++ b/RpsRuntime/ScriptOutputStream.cs
@@ -132,8 +132,7 @@ namespace RpsRuntime
 
             var actualBuffer = new byte[count];
             Array.Copy(buffer, offset, actualBuffer, 0, count);
-            // IronPython writes UTF-16LE, not UTF-8
-            var text = Encoding.Unicode.GetString(actualBuffer);
+            var text = Encoding.UTF8.GetString(actualBuffer);
 
             // Buffer the text
             _outputBuffer.Append(text);


### PR DESCRIPTION
### Purpose

Primary 2 main purposes for this PR:
- Add Dark theme for Revit 2024+
- Fix issue https://github.com/architecture-building-systems/revitpythonshell/issues/167 by using modern way to build dlls

### Description

Add reference to Microsoft.CodeAnalysis.CSharp and use it to build dlls. This is a modern way to emit dlls which is preferable and supports .NET8 and other platforms. 

A new Dark theme is now used for the interface if users choses the Revit to be in a Dark mode. It recognizes Revit theme automatically and switches theme for RPS as well 
<img width="869" height="616" alt="image" src="https://github.com/user-attachments/assets/48e5b973-b3d5-4714-b982-518e6d13fcad" />

### Declarations

Check these if you believe they are true

- [x] This PR fix bug
- [x] This PR for new feature
- [x] The codebase is in a better state after this PR
- [x] The level of testing this PR includes is appropriate
- [x] User facing strings, if any, are extracted into `*.resx` files
- [x] Snapshot of UI changes, if any.
- [x] This PR modifies some build requirements and the readme is updated

### Reviewers

@daren-thomas 

### FYIs

@daren-thomas tested for 2022